### PR TITLE
feat: add install script and command files for easy plugin installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,59 +28,73 @@ It checks whether each component follows Claude Code best practices, whether com
 
 ## Install
 
+### As a CLI tool
+
 ```bash
 uv sync
 ```
 
-With LLM support (for `review` CLI and `eval-skill --rubric`):
+Optional extras:
 
 ```bash
-uv sync --extra llm
-```
-
-With YARA signature scanning (for `security`):
-
-```bash
-uv sync --extra security
-```
-
-## Usage
-
-### As a CLI
-
-```bash
-# Fast lint: static analysis + system analysis (no LLM, CI-suitable)
-harness-eval-lab eval-setup-lint /path/to/project
-harness-eval-lab eval-setup-lint /path/to/project --preset strict --format json
-harness-eval-lab eval-setup-lint /path/to/project --fail-on-error
-
-# Qualitative review: LLM-based per-component review (requires API key)
-export GEMINI_API_KEY=your-key  # or ANTHROPIC_API_KEY
-harness-eval-lab eval-setup-review /path/to/project
-harness-eval-lab eval-setup-review /path/to/project --provider anthropic --model claude-sonnet-4-20250514
-
-# Security audit: all security rules + optional LLM semantic review
-harness-eval-lab eval-setup-security /path/to/project
-harness-eval-lab eval-setup-security /path/to/project --review --provider gemini
-
-# Deep-evaluate one skill (with setup context)
-harness-eval-lab eval-skill /path/to/skills/my-skill --context /path/to/project
-harness-eval-lab eval-skill /path/to/skills/my-skill --context /path/to/project --rubric
+uv sync --extra llm       # LLM support (for review CLI and eval-skill --rubric)
+uv sync --extra security  # YARA signature scanning (for security)
 ```
 
 ### As a Claude Code plugin
 
-Install by adding the plugin directory, then use:
+Run the install script from a clone of this repo, pointing at your workspace:
 
-- `/eval-setup-lint` - fast static analysis (no LLM)
+```bash
+git clone https://github.com/redhat-community-ai-tools/harness-eval-lab.git
+cd harness-eval-lab
+python install.py --target /path/to/your-workspace
+```
+
+This installs:
+- 4 skills into `skills/` (the evaluation engines)
+- 4 commands into `.claude/commands/` (so they appear in `/` autocomplete)
+- The `harness-eval-lab` Python package (required by the skill scripts)
+
+**Restart Claude Code after installing.** The new commands appear on the next session.
+
+To uninstall:
+
+```bash
+python install.py --target /path/to/your-workspace --uninstall
+```
+
+## Usage
+
+### CLI
+
+```bash
+harness-eval-lab eval-setup-lint /path/to/project
+harness-eval-lab eval-setup-lint /path/to/project --preset strict --format json
+harness-eval-lab eval-setup-lint /path/to/project --fail-on-error
+
+export GEMINI_API_KEY=your-key  # or ANTHROPIC_API_KEY
+harness-eval-lab eval-setup-review /path/to/project
+harness-eval-lab eval-setup-review /path/to/project --provider anthropic --model claude-sonnet-4-20250514
+
+harness-eval-lab eval-setup-security /path/to/project
+harness-eval-lab eval-setup-security /path/to/project --review --provider gemini
+
+harness-eval-lab eval-skill /path/to/skills/my-skill --context /path/to/project
+harness-eval-lab eval-skill /path/to/skills/my-skill --context /path/to/project --rubric
+```
+
+### Claude Code commands (after plugin install)
+
+- `/eval-setup-lint` - fast static analysis, no LLM, CI-suitable
 - `/eval-setup-review` - full qualitative review with KEEP/REVIEW/REMOVE verdicts
 - `/eval-setup-security` - deep security audit with deterministic scan + semantic review
 - `/eval-skill <skill-name>` - deep-evaluate one skill in context
 
-**Note on `/eval-setup-security`:** The YARA signature scanning check requires the `yara-python` package. If it is not installed, the YARA check will be skipped automatically and the report will note it was skipped. All other security checks run without extra dependencies. To enable YARA scanning, install it before running the command:
+**Note on `/eval-setup-security`:** The YARA signature scanning check requires `yara-python`. If not installed, the YARA check is skipped automatically and the report notes it. All other security checks run without extra dependencies. To enable YARA scanning:
 
 ```bash
-uv sync --extra security   # or: pip install yara-python
+pip install yara-python
 ```
 
 ## CLI Commands

--- a/commands/eval-setup-lint/command.md
+++ b/commands/eval-setup-lint/command.md
@@ -1,0 +1,13 @@
+---
+description: "Run deterministic static analysis on the full agent setup (CLAUDE.md, skills, commands, hooks, agents, MCP configs). 39 rules + system-level analysis. No LLM, fast, CI-suitable."
+---
+
+# Eval Setup Lint
+
+Use the Skill tool to invoke `eval-setup-lint` explicitly.
+
+Pass through any arguments from $ARGUMENTS (e.g., a specific path to evaluate).
+
+If the Skill tool is not available or the skill is not found, tell the user:
+- Check that `skills/eval-setup-lint/SKILL.md` exists in the workspace
+- If not, re-run `python install.py --target <workspace>` from the harness-eval-lab repo

--- a/commands/eval-setup-review/command.md
+++ b/commands/eval-setup-review/command.md
@@ -1,0 +1,13 @@
+---
+description: "Full qualitative review of the agent setup. Per-component rubrics, 21 cross-type checks, KEEP/REVIEW/REMOVE verdicts. Use for deep review, redundancy check, or quality assessment."
+---
+
+# Eval Setup Review
+
+Use the Skill tool to invoke `eval-setup-review` explicitly.
+
+Pass through any arguments from $ARGUMENTS (e.g., a specific path to evaluate).
+
+If the Skill tool is not available or the skill is not found, tell the user:
+- Check that `skills/eval-setup-review/SKILL.md` exists in the workspace
+- If not, re-run `python install.py --target <workspace>` from the harness-eval-lab repo

--- a/commands/eval-setup-security/command.md
+++ b/commands/eval-setup-security/command.md
@@ -1,0 +1,13 @@
+---
+description: "Deep security audit of the agent setup. Deterministic security rules (prompt injection, credential access, exfiltration, taint tracking, YARA, CVE) plus LLM semantic review."
+---
+
+# Eval Setup Security
+
+Use the Skill tool to invoke `eval-setup-security` explicitly.
+
+Pass through any arguments from $ARGUMENTS (e.g., a specific path to evaluate).
+
+If the Skill tool is not available or the skill is not found, tell the user:
+- Check that `skills/eval-setup-security/SKILL.md` exists in the workspace
+- If not, re-run `python install.py --target <workspace>` from the harness-eval-lab repo

--- a/commands/eval-skill/command.md
+++ b/commands/eval-skill/command.md
@@ -1,0 +1,13 @@
+---
+description: "Deep-evaluate a single skill with static analysis and qualitative review, both individually and in context of the full setup. Check if a skill is worth keeping, well-built, or redundant."
+---
+
+# Eval Skill
+
+Use the Skill tool to invoke `eval-skill` explicitly.
+
+Pass through any arguments from $ARGUMENTS (e.g., a skill name or path to evaluate).
+
+If the Skill tool is not available or the skill is not found, tell the user:
+- Check that `skills/eval-skill/SKILL.md` exists in the workspace
+- If not, re-run `python install.py --target <workspace>` from the harness-eval-lab repo

--- a/install.py
+++ b/install.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""Install or uninstall the harness-eval-lab plugin into a Claude Code workspace.
+
+Copies skills and commands into the target workspace and installs the
+harness-eval-lab Python package. No external dependencies required.
+
+Usage:
+    python install.py                              # install into current directory
+    python install.py --target /path/to/workspace  # install into specific workspace
+    python install.py --uninstall                  # remove from current directory
+"""
+
+import argparse
+import os
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent
+
+SKILLS = [
+    "eval-setup-lint",
+    "eval-setup-review",
+    "eval-setup-security",
+    "eval-skill",
+]
+
+COMMANDS = [
+    "eval-setup-lint",
+    "eval-setup-review",
+    "eval-setup-security",
+    "eval-skill",
+]
+
+FRONTMATTER_RE = re.compile(r"^---\s*\n.*?\n---\s*\n", re.DOTALL)
+
+SYMLINK_SOURCE = "eval-skill/rubric/skills-rubric.md"
+SYMLINK_TARGET = "../../eval-setup-review/rubric/skills-rubric.md"
+
+
+def find_package_manager():
+    """Find uv or pip. Returns (command, args_prefix)."""
+    uv = shutil.which("uv")
+    if uv:
+        return "uv", [uv, "pip"]
+    pip = shutil.which("pip")
+    if pip:
+        return "pip", [pip]
+    return None, None
+
+
+def install_skills(target: Path):
+    """Copy skill directories into <target>/skills/."""
+    skills_dir = target / "skills"
+    skills_dir.mkdir(parents=True, exist_ok=True)
+
+    for skill in SKILLS:
+        src = REPO_ROOT / "skills" / skill
+        dst = skills_dir / skill
+
+        if not src.exists():
+            print(f"  WARNING: skill source not found: {src}", file=sys.stderr)
+            continue
+
+        if dst.exists():
+            shutil.rmtree(dst)
+        shutil.copytree(src, dst, symlinks=False)
+        print(f"  skills/{skill}/")
+
+    # Recreate the symlink in eval-skill/rubric/
+    symlink_path = skills_dir / SYMLINK_SOURCE
+    if symlink_path.exists() or symlink_path.is_symlink():
+        symlink_path.unlink()
+    symlink_path.symlink_to(SYMLINK_TARGET)
+
+
+def install_commands(target: Path):
+    """Copy command files into <target>/.claude/commands/."""
+    commands_dir = target / ".claude" / "commands"
+    commands_dir.mkdir(parents=True, exist_ok=True)
+
+    for cmd in COMMANDS:
+        src = REPO_ROOT / "commands" / cmd / "command.md"
+        dst = commands_dir / f"{cmd}.md"
+
+        if not src.exists():
+            print(f"  WARNING: command source not found: {src}", file=sys.stderr)
+            continue
+
+        shutil.copy2(src, dst)
+        print(f"  .claude/commands/{cmd}.md")
+
+
+def install_package():
+    """Install the harness-eval-lab Python package from local checkout."""
+    manager, prefix = find_package_manager()
+    if not prefix:
+        print(
+            "  WARNING: neither uv nor pip found, skipping package install.",
+            file=sys.stderr,
+        )
+        print("  Install manually: pip install <path-to-harness-eval-lab>")
+        return False
+
+    print(f"  installing harness-eval-lab via {manager}...")
+    cmd = [*prefix, "install", str(REPO_ROOT)]
+    result = subprocess.run(cmd, capture_output=True, text=True)
+
+    if result.returncode != 0:
+        print(f"  WARNING: package install failed: {result.stderr}", file=sys.stderr)
+        return False
+
+    print("  harness-eval-lab package installed")
+    return True
+
+
+def uninstall_skills(target: Path):
+    """Remove skill directories from <target>/skills/."""
+    for skill in SKILLS:
+        path = target / "skills" / skill
+        if path.exists():
+            shutil.rmtree(path)
+            print(f"  removed skills/{skill}/")
+
+
+def uninstall_commands(target: Path):
+    """Remove command files from <target>/.claude/commands/."""
+    for cmd in COMMANDS:
+        path = target / ".claude" / "commands" / f"{cmd}.md"
+        if path.exists():
+            path.unlink()
+            print(f"  removed .claude/commands/{cmd}.md")
+
+
+def uninstall_package():
+    """Uninstall the harness-eval-lab Python package."""
+    manager, prefix = find_package_manager()
+    if not prefix:
+        return
+
+    cmd = [*prefix, "uninstall", "harness-eval-lab"]
+    if manager == "pip":
+        cmd.append("-y")
+    subprocess.run(cmd, capture_output=True, text=True)
+    print("  harness-eval-lab package uninstalled")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Install or uninstall harness-eval-lab plugin into a Claude Code workspace.",
+    )
+    parser.add_argument(
+        "--target",
+        type=Path,
+        default=Path.cwd(),
+        help="Workspace directory to install into (default: current directory)",
+    )
+    parser.add_argument(
+        "--uninstall",
+        action="store_true",
+        help="Remove installed skills, commands, and package",
+    )
+    args = parser.parse_args()
+
+    target = args.target.resolve()
+
+    if args.uninstall:
+        print(f"Uninstalling harness-eval-lab from {target}\n")
+        uninstall_skills(target)
+        uninstall_commands(target)
+        uninstall_package()
+        print("\nDone. Restart Claude Code to apply changes.")
+        return
+
+    print(f"Installing harness-eval-lab into {target}\n")
+
+    print("Skills:")
+    install_skills(target)
+
+    print("\nCommands:")
+    install_commands(target)
+
+    print("\nPackage:")
+    install_package()
+
+    print(f"""
+Done. Restart Claude Code to pick up the new commands.
+
+Available commands after restart:
+  /eval-setup-lint      fast static analysis (no LLM)
+  /eval-setup-review    full qualitative review
+  /eval-setup-security  deep security audit
+  /eval-skill           evaluate a single skill
+""")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Added `install.py` script for one-command plugin installation into any Claude Code workspace
- Added `commands/` directory with 4 command files so `/eval-setup-lint`, `/eval-setup-review`, `/eval-setup-security`, `/eval-skill` appear in autocomplete
- Rewrote README install section with clear instructions

## Problem

The repo shipped skills but no Claude Code commands. Users couldn't discover or invoke the plugin because skills don't appear in `/` autocomplete. There was also no install mechanism beyond "add the plugin directory."

## What changed

- `install.py` copies skills + commands + installs the Python package in one step, supports `--uninstall`
- `commands/eval-setup-*/command.md` are thin wrappers that invoke the corresponding skill via the Skill tool
- `README.md` install section rewritten with clear plugin install instructions

## Test plan

- [x] Tested `install.py --target` on a real workspace, all 4 skills + 4 commands installed correctly
- [x] Tested `install.py --uninstall`, all files removed cleanly
- [x] Tested reinstall after uninstall, idempotent
- [x] Verified skills are detected by Claude Code in-session
- [x] Verified symlink in eval-skill/rubric is preserved correctly