### PR TITLE
feat: add marketplace.json for self-hosted plugin marketplace

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,10 @@
+{
+  "version": "1.0",
+  "plugins": [
+    {
+      "source": "github",
+      "name": "harness-eval-lab",
+      "path": "."
+    }
+  ]
+}


### PR DESCRIPTION
Adds `.claude-plugin/marketplace.json` so this repo serves as both a plugin and its own marketplace.

Users can now install with:
```
/plugin marketplace add redhat-community-ai-tools/harness-eval-lab
/plugin install harness-eval-lab
```

One new file, no other changes.