### PR TITLE
fix: correct plugin install command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ Install directly from within Claude Code:
 
 ```
 /plugin marketplace add redhat-community-ai-tools/harness-eval-lab
-/plugin install harness-eval-lab
+/plugin install harness-eval-lab@harness-eval-lab
+/reload-plugins
 ```
 
 Or test locally during development:


### PR DESCRIPTION
Fix the install command to use `plugin@marketplace` syntax and add `/reload-plugins` step.