### PR TITLE
fix: use github source type in marketplace.json

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,10 +14,8 @@
       },
       "category": "development",
       "source": {
-        "source": "git-subdir",
-        "url": "https://github.com/redhat-community-ai-tools/harness-eval-lab.git",
-        "path": ".",
-        "ref": "main"
+        "source": "github",
+        "repo": "redhat-community-ai-tools/harness-eval-lab"
       },
       "homepage": "https://github.com/redhat-community-ai-tools/harness-eval-lab"
     }


### PR DESCRIPTION
The `git-subdir` source with `path: \".\"` only fetched root-level files into the plugin cache, missing `skills/`, `commands/`, and `.claude-plugin/` directories entirely. Switch to `github` source type which clones the full repo.