### PR TITLE
feat: add tool-aware evaluation for Cursor setups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- Tool-aware rule filtering: rules can declare `tools=("claude",)` or `tools=("cursor",)` to only run for matching components
+- `source_tool` field on `ParsedComponent` and `RuleContext` to track whether a component came from `.claude/` or `.cursor/`
+- Cursor-aware budget analysis: respects `alwaysApply` frontmatter in `.mdc` files instead of treating all Cursor rules as always-loaded
+- Tool-aware report labels: Cursor-only setups show "Cursor Rules" instead of "CLAUDE.md" in reports
+- 8 new Cursor-specific tests (source_tool tracking, rule filtering, budget, report labels)
+
+### Changed
+- `claude-md/exists`, `claude-md/generic-advice`, and `command/shadows-builtin` rules now only fire for Claude Code components (skipped for Cursor)
+- `claude-md/skill-duplication` uses Cursor-appropriate message text when evaluating Cursor rules
+- System analysis messages use tool-aware labels ("cursor rules" vs "CLAUDE.md")
+
 ## [3.4.0] - 2026-06-18
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,11 +67,13 @@ class MyNewRule:
             "message_id": "What to tell the user: {{variable}}",
         },
         target_type=ComponentType.SKILL,   # what component this applies to
+        tools=None,                        # None = all tools; ("claude",) = Claude Code only; ("cursor",) = Cursor only
     )
 
     def create(self, context: RuleContext) -> None:
         # Access the component via context.skill, context.command,
         # context.claude_md, context.hooks, or context.agent
+        # Use context.source_tool ("claude", "cursor", or None) for tool-specific behavior
         skill = context.skill
         if not skill.raw_content:
             return

--- a/src/harness_eval_lab/analysis/budget.py
+++ b/src/harness_eval_lab/analysis/budget.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 
-from harness_eval_lab.core.types import ComponentType, Setup
+from harness_eval_lab.core.types import ComponentType, ParsedComponent, Setup
 
 
 @dataclass
@@ -21,8 +21,17 @@ class BudgetReport:
     heaviest_component_ratio: float = 0.0
 
 
-ALWAYS_LOADED_TYPES = {ComponentType.CLAUDE_MD, ComponentType.HOOKS}
 _EXCLUDED_FROM_BUDGET = {ComponentType.UNCATEGORIZED}
+
+
+def _is_always_loaded(comp: ParsedComponent) -> bool:
+    if comp.component_type == ComponentType.HOOKS:
+        return True
+    if comp.component_type != ComponentType.CLAUDE_MD:
+        return False
+    if comp.source_tool != "cursor":
+        return True
+    return bool(comp.frontmatter and comp.frontmatter.get("alwaysApply") is True)
 
 
 def analyze_budget(setup: Setup) -> BudgetReport:
@@ -41,7 +50,7 @@ def analyze_budget(setup: Setup) -> BudgetReport:
         by_type[type_key] = by_type.get(type_key, 0) + comp.token_count
         by_component.append((type_key, comp.name, comp.token_count))
 
-        if comp.component_type in ALWAYS_LOADED_TYPES:
+        if _is_always_loaded(comp):
             always_loaded += comp.token_count
         else:
             on_demand += comp.token_count

--- a/src/harness_eval_lab/analysis/system.py
+++ b/src/harness_eval_lab/analysis/system.py
@@ -41,10 +41,15 @@ def analyze_system(setup: Setup) -> SystemReport:
 
     findings: list[str] = []
 
+    if "Cursor" in setup.detected_tools and "Claude Code" not in setup.detected_tools:
+        always_label = "cursor rules"
+    else:
+        always_label = "CLAUDE.md"
+
     if budget.always_loaded_ratio > 0.7:
         findings.append(
             f"Inverted budget: {budget.always_loaded_ratio:.0%} of tokens are "
-            f"always-loaded (CLAUDE.md). Most content should be in on-demand skills."
+            f"always-loaded ({always_label}). Most content should be in on-demand skills."
         )
     elif budget.always_loaded_ratio > 0.5:
         findings.append(

--- a/src/harness_eval_lab/core/setup.py
+++ b/src/harness_eval_lab/core/setup.py
@@ -65,6 +65,7 @@ def _parse_file(
     component_type: ComponentType,
     name: str | None = None,
     scope: ComponentScope = ComponentScope.PROJECT,
+    source_tool: str | None = None,
 ) -> ParsedComponent:
     content = filepath.read_text(encoding="utf-8", errors="replace")
     frontmatter, _ = parse_frontmatter(content)
@@ -76,6 +77,7 @@ def _parse_file(
         frontmatter=frontmatter,
         token_count=count_tokens(content),
         scope=scope,
+        source_tool=source_tool,
     )
 
 
@@ -93,7 +95,7 @@ def _discover_claude_md(
                 resolved = str(f.resolve())
                 if resolved not in seen_paths:
                     seen_paths.add(resolved)
-                    results.append(_parse_file(f, ComponentType.CLAUDE_MD))
+                    results.append(_parse_file(f, ComponentType.CLAUDE_MD, source_tool="claude"))
 
     if user_config_dir is None:
         return results
@@ -110,6 +112,7 @@ def _discover_claude_md(
                     ComponentType.CLAUDE_MD,
                     name="CLAUDE.md (user-global)",
                     scope=ComponentScope.USER_GLOBAL,
+                    source_tool="claude",
                 )
             )
 
@@ -130,6 +133,7 @@ def _discover_claude_md(
                             ComponentType.CLAUDE_MD,
                             name=f"CLAUDE.md (user-project: {project_dir.name})",
                             scope=ComponentScope.USER_PROJECT,
+                            source_tool="claude",
                         )
                     )
 
@@ -142,13 +146,16 @@ def _discover_skills(root: Path) -> list[ParsedComponent]:
     for skills_dir in [root / "skills", root / ".claude" / "skills"]:
         if not skills_dir.is_dir():
             continue
+        tool = "claude" if ".claude" in skills_dir.parts else None
         for skill_md in sorted(skills_dir.rglob("SKILL.md")):
             resolved = str(skill_md.resolve())
             if resolved in seen_paths:
                 continue
             seen_paths.add(resolved)
             skill_dir = skill_md.parent
-            results.append(_parse_file(skill_md, ComponentType.SKILL, name=skill_dir.name))
+            results.append(
+                _parse_file(skill_md, ComponentType.SKILL, name=skill_dir.name, source_tool=tool)
+            )
     return results
 
 
@@ -157,20 +164,25 @@ def _discover_commands(root: Path) -> list[ParsedComponent]:
     for commands_dir in [root / "commands", root / ".claude" / "commands"]:
         if not commands_dir.is_dir():
             continue
+        tool = "claude" if ".claude" in commands_dir.parts else None
         for item in sorted(commands_dir.iterdir()):
             if item.is_file() and item.suffix == ".md":
-                results.append(_parse_file(item, ComponentType.COMMAND))
+                results.append(_parse_file(item, ComponentType.COMMAND, source_tool=tool))
             elif item.is_dir():
                 cmd_md = item / "command.md"
                 if cmd_md.is_file():
-                    results.append(_parse_file(cmd_md, ComponentType.COMMAND, name=item.name))
+                    results.append(
+                        _parse_file(cmd_md, ComponentType.COMMAND, name=item.name, source_tool=tool)
+                    )
     return results
 
 
 def _discover_hooks(root: Path) -> list[ParsedComponent]:
     settings = root / ".claude" / "settings.json"
     if settings.is_file():
-        return [_parse_file(settings, ComponentType.HOOKS, name="settings.json")]
+        return [
+            _parse_file(settings, ComponentType.HOOKS, name="settings.json", source_tool="claude")
+        ]
     return []
 
 
@@ -181,7 +193,7 @@ def _discover_agents(root: Path) -> list[ParsedComponent]:
         return results
     for f in sorted(agents_dir.glob("*.md")):
         if f.is_file():
-            results.append(_parse_file(f, ComponentType.AGENT))
+            results.append(_parse_file(f, ComponentType.AGENT, source_tool="claude"))
     return results
 
 
@@ -207,7 +219,7 @@ def _discover_rules(root: Path) -> list[ParsedComponent]:
         return results
     for f in sorted(rules_dir.rglob("*")):
         if f.is_file() and f.suffix in (".md", ".yaml", ".yml"):
-            results.append(_parse_file(f, ComponentType.RULE, name=f.stem))
+            results.append(_parse_file(f, ComponentType.RULE, name=f.stem, source_tool="claude"))
     return results
 
 
@@ -218,7 +230,9 @@ def _discover_output_styles(root: Path) -> list[ParsedComponent]:
         return results
     for f in sorted(styles_dir.rglob("*")):
         if f.is_file() and f.suffix in (".md", ".yaml", ".yml"):
-            results.append(_parse_file(f, ComponentType.OUTPUT_STYLE, name=f.stem))
+            results.append(
+                _parse_file(f, ComponentType.OUTPUT_STYLE, name=f.stem, source_tool="claude")
+            )
     return results
 
 
@@ -233,7 +247,9 @@ def _discover_cursor_rules(root: Path) -> list[ParsedComponent]:
                 resolved = str(f.resolve())
                 if resolved not in seen_paths:
                     seen_paths.add(resolved)
-                    results.append(_parse_file(f, ComponentType.CLAUDE_MD, name=f.stem))
+                    results.append(
+                        _parse_file(f, ComponentType.CLAUDE_MD, name=f.stem, source_tool="cursor")
+                    )
 
     for f in sorted(root.rglob(".cursorrules")):
         if f.is_file() and ".git" not in f.parts:
@@ -242,7 +258,9 @@ def _discover_cursor_rules(root: Path) -> list[ParsedComponent]:
                 seen_paths.add(resolved)
                 rel = f.relative_to(root)
                 name = str(rel) if rel != Path(".cursorrules") else ".cursorrules"
-                results.append(_parse_file(f, ComponentType.CLAUDE_MD, name=name))
+                results.append(
+                    _parse_file(f, ComponentType.CLAUDE_MD, name=name, source_tool="cursor")
+                )
 
     return results
 
@@ -254,7 +272,7 @@ def _discover_cursor_commands(root: Path) -> list[ParsedComponent]:
         return results
     for f in sorted(commands_dir.iterdir()):
         if f.is_file() and f.suffix == ".md":
-            results.append(_parse_file(f, ComponentType.COMMAND, name=f.stem))
+            results.append(_parse_file(f, ComponentType.COMMAND, name=f.stem, source_tool="cursor"))
     return results
 
 
@@ -268,21 +286,31 @@ def _discover_cursor_skills(root: Path) -> list[ParsedComponent]:
         resolved = str(skill_md.resolve())
         if resolved not in seen_paths:
             seen_paths.add(resolved)
-            results.append(_parse_file(skill_md, ComponentType.SKILL, name=skill_md.parent.name))
+            results.append(
+                _parse_file(
+                    skill_md, ComponentType.SKILL, name=skill_md.parent.name, source_tool="cursor"
+                )
+            )
     return results
 
 
 def _discover_cursor_hooks(root: Path) -> list[ParsedComponent]:
     hooks_file = root / ".cursor" / "hooks.json"
     if hooks_file.is_file():
-        return [_parse_file(hooks_file, ComponentType.HOOKS, name="hooks.json")]
+        return [
+            _parse_file(hooks_file, ComponentType.HOOKS, name="hooks.json", source_tool="cursor")
+        ]
     return []
 
 
 def _discover_cursor_mcp(root: Path) -> list[ParsedComponent]:
     mcp_file = root / ".cursor" / "mcp.json"
     if mcp_file.is_file():
-        return [_parse_file(mcp_file, ComponentType.MCP_CONFIG, name=".cursor/mcp.json")]
+        return [
+            _parse_file(
+                mcp_file, ComponentType.MCP_CONFIG, name=".cursor/mcp.json", source_tool="cursor"
+            )
+        ]
     return []
 
 

--- a/src/harness_eval_lab/core/types.py
+++ b/src/harness_eval_lab/core/types.py
@@ -35,6 +35,7 @@ class ParsedComponent:
     frontmatter: dict[str, object] | None = None
     token_count: int = 0
     scope: ComponentScope = ComponentScope.PROJECT
+    source_tool: str | None = None
 
 
 @dataclass(frozen=True)

--- a/src/harness_eval_lab/inspection/engine.py
+++ b/src/harness_eval_lab/inspection/engine.py
@@ -155,6 +155,7 @@ def _run_rules(
     all_skills: list[ParsedSkill] | None = None,
     all_commands: list[ParsedCommand] | None = None,
     scan_state: dict[str, Any] | None = None,
+    source_tool: str | None = None,
 ) -> tuple[list[Finding], int, list[RuleResult]]:
     """Run rules for a given target type. Returns (findings, suppression_count, rules_run)."""
     findings: list[Finding] = []
@@ -183,6 +184,13 @@ def _run_rules(
         if rule.meta.target_type != target_type:
             continue
 
+        if (
+            rule.meta.tools is not None
+            and source_tool is not None
+            and source_tool not in rule.meta.tools
+        ):
+            continue
+
         resolved = _resolve_severity(rule, config_rules)
         if resolved is None:
             continue
@@ -209,6 +217,7 @@ def _run_rules(
             all_skills=all_skills or [],
             all_commands=all_commands or [],
             scan_state=scan_state,
+            source_tool=source_tool,
         )
         rule.create(context)
 
@@ -254,6 +263,7 @@ def lint(
     scan_state: dict[str, Any] | None = None,
     all_skills: list[ParsedSkill] | None = None,
     all_commands: list[ParsedCommand] | None = None,
+    source_tool: str | None = None,
 ) -> InspectionResult:
     """Lint a single skill directory or SKILL.md file."""
     skill = parse_skill(skill_path)
@@ -273,6 +283,7 @@ def lint(
         scan_state=scan_state,
         all_skills=all_skills,
         all_commands=all_commands,
+        source_tool=source_tool,
     )
     diagnostics.extend(rule_diags)
 
@@ -293,6 +304,7 @@ def lint_command(
     all_skills: list[ParsedSkill] | None = None,
     all_commands: list[ParsedCommand] | None = None,
     scan_state: dict[str, Any] | None = None,
+    source_tool: str | None = None,
 ) -> InspectionResult:
     """Lint a single command directory."""
     cmd = parse_command(command_path)
@@ -308,6 +320,7 @@ def lint_command(
         all_skills=all_skills,
         all_commands=all_commands,
         scan_state=scan_state,
+        source_tool=source_tool,
     )
     diagnostics.extend(rule_diags)
 
@@ -327,6 +340,7 @@ def lint_claude_md(
     config_rules: dict[str, str | list[Any]] | None = None,
     all_skills: list[ParsedSkill] | None = None,
     scan_state: dict[str, Any] | None = None,
+    source_tool: str | None = None,
 ) -> InspectionResult:
     """Lint a CLAUDE.md file."""
     claude_md = parse_claude_md(file_path)
@@ -341,6 +355,7 @@ def lint_claude_md(
         config_rules=config_rules,
         all_skills=all_skills,
         scan_state=scan_state,
+        source_tool=source_tool,
     )
     diagnostics.extend(rule_diags)
 
@@ -359,6 +374,7 @@ def lint_hooks(
     settings_path: str,
     config_rules: dict[str, str | list[Any]] | None = None,
     scan_state: dict[str, Any] | None = None,
+    source_tool: str | None = None,
 ) -> InspectionResult:
     """Lint hooks from settings.json."""
     hooks = parse_hooks(settings_path)
@@ -372,6 +388,7 @@ def lint_hooks(
         target=hooks,
         config_rules=config_rules,
         scan_state=scan_state,
+        source_tool=source_tool,
     )
     diagnostics.extend(rule_diags)
 
@@ -391,6 +408,7 @@ def lint_agent(
     config_rules: dict[str, str | list[Any]] | None = None,
     all_skills: list[ParsedSkill] | None = None,
     scan_state: dict[str, Any] | None = None,
+    source_tool: str | None = None,
 ) -> InspectionResult:
     """Lint a single agent .md file."""
     agent = parse_agent(agent_path)
@@ -405,6 +423,7 @@ def lint_agent(
         config_rules=config_rules,
         all_skills=all_skills,
         scan_state=scan_state,
+        source_tool=source_tool,
     )
     diagnostics.extend(rule_diags)
 
@@ -434,6 +453,7 @@ def lint_text_file(
     component_type: ComponentType,
     config_rules: dict[str, str | list[Any]] | None = None,
     scan_state: dict[str, Any] | None = None,
+    source_tool: str | None = None,
 ) -> InspectionResult:
     """Lint a generic text file (rule, output-style) using security-only rules."""
     path = Path(file_path)
@@ -475,6 +495,7 @@ def lint_text_file(
         target=dummy_skill,
         config_rules=security_config,
         scan_state=scan_state,
+        source_tool=source_tool,
     )
 
     return _build_result(
@@ -516,6 +537,7 @@ def inspect_setup(
                 scan_state=scan_state,
                 all_skills=all_skills,
                 all_commands=all_commands,
+                source_tool=comp.source_tool,
             )
         )
     for comp in setup.by_type(CT.COMMAND):
@@ -528,6 +550,7 @@ def inspect_setup(
                     all_skills=all_skills,
                     all_commands=all_commands,
                     scan_state=scan_state,
+                    source_tool=comp.source_tool,
                 )
             )
         else:
@@ -538,21 +561,46 @@ def inspect_setup(
                     all_skills=all_skills,
                     all_commands=all_commands,
                     scan_state=scan_state,
+                    source_tool=comp.source_tool,
                 )
             )
     for comp in setup.by_type(CT.CLAUDE_MD):
         results.append(
-            lint_claude_md(comp.path, config_rules, all_skills=all_skills, scan_state=scan_state)
+            lint_claude_md(
+                comp.path,
+                config_rules,
+                all_skills=all_skills,
+                scan_state=scan_state,
+                source_tool=comp.source_tool,
+            )
         )
     for comp in setup.by_type(CT.HOOKS):
-        results.append(lint_hooks(comp.path, config_rules, scan_state=scan_state))
+        results.append(
+            lint_hooks(comp.path, config_rules, scan_state=scan_state, source_tool=comp.source_tool)
+        )
     for comp in setup.by_type(CT.AGENT):
-        results.append(lint_agent(comp.path, config_rules, scan_state=scan_state))
+        results.append(
+            lint_agent(comp.path, config_rules, scan_state=scan_state, source_tool=comp.source_tool)
+        )
     for comp in setup.by_type(CT.RULE):
-        results.append(lint_text_file(comp.path, CT.RULE, config_rules, scan_state=scan_state))
+        results.append(
+            lint_text_file(
+                comp.path,
+                CT.RULE,
+                config_rules,
+                scan_state=scan_state,
+                source_tool=comp.source_tool,
+            )
+        )
     for comp in setup.by_type(CT.OUTPUT_STYLE):
         results.append(
-            lint_text_file(comp.path, CT.OUTPUT_STYLE, config_rules, scan_state=scan_state)
+            lint_text_file(
+                comp.path,
+                CT.OUTPUT_STYLE,
+                config_rules,
+                scan_state=scan_state,
+                source_tool=comp.source_tool,
+            )
         )
     return results
 

--- a/src/harness_eval_lab/inspection/rules/claude_md/exists.py
+++ b/src/harness_eval_lab/inspection/rules/claude_md/exists.py
@@ -22,6 +22,7 @@ class ClaudeMdExists:
             "not_found": "No CLAUDE.md found — consider creating one with project-specific instructions (build commands, test runners, code style). See https://code.claude.com/docs/en/best-practices",
         },
         target_type=ComponentType.CLAUDE_MD,
+        tools=("claude",),
     )
 
     def create(self, context: RuleContext) -> None:

--- a/src/harness_eval_lab/inspection/rules/claude_md/generic_advice.py
+++ b/src/harness_eval_lab/inspection/rules/claude_md/generic_advice.py
@@ -42,6 +42,7 @@ class ClaudeMdGenericAdvice:
             "generic": "Line {{line}}: '{{label}}' — Claude does this by default. This instruction wastes tokens every session.",
         },
         target_type=ComponentType.CLAUDE_MD,
+        tools=("claude",),
     )
 
     def create(self, context: RuleContext) -> None:

--- a/src/harness_eval_lab/inspection/rules/claude_md/skill_duplication.py
+++ b/src/harness_eval_lab/inspection/rules/claude_md/skill_duplication.py
@@ -23,6 +23,7 @@ class ClaudeMdSkillDuplication:
         category=RuleCategory.CONTENT,
         messages={
             "overlap": "CLAUDE.md section '{{section}}' has {{pct}}% similarity with skill '{{skill}}' — consider removing the duplicate content from CLAUDE.md since the skill loads on demand",
+            "overlap_cursor": "Rules section '{{section}}' has {{pct}}% similarity with skill '{{skill}}' — consider removing the duplicate content from the rule file since the skill loads on demand",
         },
         target_type=ComponentType.CLAUDE_MD,
     )
@@ -43,9 +44,10 @@ class ClaudeMdSkillDuplication:
 
                 similarity = tfidf_similarity(section_text, skill.body)
                 if similarity >= OVERLAP_THRESHOLD:
+                    msg_id = "overlap_cursor" if context.source_tool == "cursor" else "overlap"
                     context.report(
                         ReportDescriptor(
-                            message_id="overlap",
+                            message_id=msg_id,
                             data={
                                 "section": section.get("header", "(untitled)"),
                                 "pct": str(int(similarity * 100)),

--- a/src/harness_eval_lab/inspection/rules/commands/shadows_builtin.py
+++ b/src/harness_eval_lab/inspection/rules/commands/shadows_builtin.py
@@ -41,6 +41,7 @@ class CommandShadowsBuiltin:
             "shadows": "Command '{{name}}' shadows the built-in /{{name}} command — the built-in will be overridden, which may be unintentional",
         },
         target_type=ComponentType.COMMAND,
+        tools=("claude",),
     )
 
     def create(self, context: RuleContext) -> None:

--- a/src/harness_eval_lab/inspection/types.py
+++ b/src/harness_eval_lab/inspection/types.py
@@ -53,6 +53,7 @@ class RuleMeta:
     category: RuleCategory
     messages: dict[str, str]
     target_type: ComponentType = ComponentType.SKILL
+    tools: tuple[str, ...] | None = None
 
 
 @dataclass
@@ -147,6 +148,7 @@ class RuleContext:
     all_skills: list[ParsedSkill] = field(default_factory=list)
     all_commands: list[ParsedCommand] = field(default_factory=list)
     scan_state: dict[str, Any] = field(default_factory=dict)
+    source_tool: str | None = None
 
     @property
     def command(self) -> ParsedCommand | None:

--- a/src/harness_eval_lab/output/report.py
+++ b/src/harness_eval_lab/output/report.py
@@ -8,15 +8,26 @@ from collections import defaultdict
 from harness_eval_lab.analysis.system import SystemReport
 from harness_eval_lab.inspection.types import InspectionResult
 
-_TYPE_DISPLAY = {
-    "skill": "Skills",
-    "command": "Commands",
-    "hooks": "Hooks",
-    "claude_md": "CLAUDE.md",
-    "agent": "Agents",
-    "rule": "Rules",
-    "output_style": "Output Styles",
-}
+
+def _get_type_display(detected_tools: tuple[str, ...] = ()) -> dict[str, str]:
+    base = {
+        "skill": "Skills",
+        "command": "Commands",
+        "hooks": "Hooks",
+        "agent": "Agents",
+        "rule": "Rules",
+        "output_style": "Output Styles",
+    }
+    if "Cursor" in detected_tools and "Claude Code" not in detected_tools:
+        base["claude_md"] = "Cursor Rules"
+    elif "Claude Code" in detected_tools and "Cursor" not in detected_tools:
+        base["claude_md"] = "CLAUDE.md"
+    elif "Cursor" in detected_tools and "Claude Code" in detected_tools:
+        base["claude_md"] = "System Instructions"
+    else:
+        base["claude_md"] = "CLAUDE.md"
+    return base
+
 
 _TYPE_ORDER = ["skill", "command", "hooks", "claude_md", "agent", "rule", "output_style"]
 
@@ -71,10 +82,15 @@ def format_terminal(
     lines.append("  SKIP     Check was skipped (missing dependency or N/A)")
     lines.append("")
 
+    if "Cursor" in system.detected_tools and "Claude Code" not in system.detected_tools:
+        always_label = "cursor rules, hooks"
+    else:
+        always_label = "CLAUDE.md, hooks"
+
     lines.append("Token Budget:")
     lines.append(f"{'─' * 60}")
     lines.append(
-        f"  Always-loaded (CLAUDE.md, hooks): "
+        f"  Always-loaded ({always_label}): "
         f"{system.budget.always_loaded_tokens} tokens "
         f"({system.budget.always_loaded_ratio:.0%})"
     )
@@ -149,7 +165,7 @@ def format_terminal(
 
         for type_key in all_type_keys:
             results = grouped[type_key]
-            label = _TYPE_DISPLAY.get(type_key, type_key)
+            label = _get_type_display(system.detected_tools).get(type_key, type_key)
             lines.append("")
             lines.append(f"  {label} ({len(results)})")
             lines.append(f"  {'─' * 56}")

--- a/tests/test_cursor_discovery.py
+++ b/tests/test_cursor_discovery.py
@@ -4,9 +4,12 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from harness_eval_lab.analysis.budget import analyze_budget
+from harness_eval_lab.analysis.system import analyze_system
 from harness_eval_lab.core.setup import discover_setup
 from harness_eval_lab.core.types import ComponentType
 from harness_eval_lab.inspection.engine import inspect_setup, lint_claude_md, lint_hooks
+from harness_eval_lab.output.report import format_terminal
 
 FIXTURES_DIR = Path(__file__).parent / "fixtures"
 
@@ -93,6 +96,71 @@ class TestCursorLinting:
         setup = discover_setup(name="mixed", path=str(FIXTURES_DIR / "sample-mixed-setup"))
         results = inspect_setup(setup)
         assert len(results) > 0
+
+
+class TestCursorSourceTool:
+    def test_cursor_components_have_source_tool(self) -> None:
+        setup = discover_setup(name="cursor", path=str(FIXTURES_DIR / "sample-cursor-setup"))
+        for comp in setup.components:
+            if ".cursor" in comp.path or ".cursorrules" in comp.path:
+                assert comp.source_tool == "cursor", f"{comp.path} should have source_tool='cursor'"
+
+    def test_mixed_setup_has_both_source_tools(self) -> None:
+        setup = discover_setup(name="mixed", path=str(FIXTURES_DIR / "sample-mixed-setup"))
+        claude_comps = [c for c in setup.components if c.source_tool == "claude"]
+        cursor_comps = [c for c in setup.components if c.source_tool == "cursor"]
+        assert len(claude_comps) > 0
+        assert len(cursor_comps) > 0
+
+
+class TestCursorRuleFiltering:
+    def test_claude_md_exists_not_fired_for_cursor(self) -> None:
+        setup = discover_setup(name="cursor", path=str(FIXTURES_DIR / "sample-cursor-setup"))
+        config = {"claude-md/exists": "warning"}
+        results = inspect_setup(setup, config)
+        for r in results:
+            for d in r.diagnostics:
+                assert d.rule_id != "claude-md/exists", (
+                    "claude-md/exists should not fire for Cursor setup"
+                )
+
+    def test_generic_advice_not_fired_for_cursor(self) -> None:
+        setup = discover_setup(name="cursor", path=str(FIXTURES_DIR / "sample-cursor-setup"))
+        config = {"claude-md/generic-advice": "warning"}
+        results = inspect_setup(setup, config)
+        for r in results:
+            for d in r.diagnostics:
+                assert d.rule_id != "claude-md/generic-advice", (
+                    "generic-advice should not fire for Cursor components"
+                )
+
+
+class TestCursorBudget:
+    def test_cursor_non_always_apply_is_on_demand(self) -> None:
+        setup = discover_setup(name="cursor", path=str(FIXTURES_DIR / "sample-cursor-setup"))
+        budget = analyze_budget(setup)
+        assert budget.on_demand_tokens > 0
+
+    def test_cursor_always_apply_is_always_loaded(self) -> None:
+        setup = discover_setup(name="cursor", path=str(FIXTURES_DIR / "sample-cursor-setup"))
+        budget = analyze_budget(setup)
+        assert budget.always_loaded_tokens > 0
+
+
+class TestCursorReport:
+    def test_cursor_only_report_labels(self) -> None:
+        setup = discover_setup(name="cursor", path=str(FIXTURES_DIR / "sample-cursor-setup"))
+        system = analyze_system(setup)
+        results = inspect_setup(setup)
+        output = format_terminal(system, results)
+        assert "Cursor Rules" in output
+
+    def test_cursor_budget_label(self) -> None:
+        setup = discover_setup(name="cursor", path=str(FIXTURES_DIR / "sample-cursor-setup"))
+        system = analyze_system(setup)
+        results = inspect_setup(setup)
+        output = format_terminal(system, results)
+        assert "cursor rules, hooks" in output
 
 
 class TestDeduplication:


### PR DESCRIPTION
## Summary

- Adds `source_tool` tracking to `ParsedComponent` so the system knows whether a component came from `.claude/` or `.cursor/`
- Rules can now declare `tools=("claude",)` to only run for Claude Code components, leaving Cursor setups unaffected
- Cursor budget analysis respects `alwaysApply` frontmatter instead of treating all Cursor rules as always-loaded
- Reports show "Cursor Rules" instead of "CLAUDE.md" for Cursor-only setups

## What changed

**Claude Code users:** Zero behavioral change. Output is byte-identical (verified by diffing fixture output before/after).

**Cursor users get correct evaluation:**

| Before | After |
|--------|-------|
| `Always-loaded (CLAUDE.md, hooks): 262 tokens (65%)` | `Always-loaded (cursor rules, hooks): 180 tokens (45%)` |
| False warning: "Heavy always-loaded ratio: 65%..." | No false warning (budget correctly splits by `alwaysApply`) |
| Section header: `CLAUDE.md (3)` | Section header: `Cursor Rules (3)` |
| `claude-md/exists` fires: "No CLAUDE.md found" | Skipped (irrelevant for Cursor) |
| `claude-md/generic-advice` fires for `.cursorrules` | Skipped (Claude-specific defaults) |
| `command/shadows-builtin` checks Claude's builtins | Skipped (Cursor has different builtins) |

## Files changed (14)

- `core/types.py`: Added `source_tool` field to `ParsedComponent`
- `core/setup.py`: Set `source_tool` in all 13 discovery functions
- `inspection/types.py`: Added `tools` filter to `RuleMeta`, `source_tool` to `RuleContext`
- `inspection/engine.py`: Threaded `source_tool` through all lint functions + filtering logic
- 4 rule files: Tagged Claude-specific rules, tool-aware messaging
- `analysis/budget.py`: Respects Cursor `alwaysApply` frontmatter
- `analysis/system.py` + `output/report.py`: Tool-aware labels and messages
- `tests/test_cursor_discovery.py`: 8 new tests
- `CHANGELOG.md` + `CONTRIBUTING.md`: Updated docs

## Test plan

- [x] 188 tests pass (8 new Cursor-specific tests)
- [x] Lint clean (`ruff check` + `ruff format`)
- [x] mypy unchanged (50 pre-existing errors, 0 new)
- [x] Claude Code fixture output identical (only timing differs)
- [x] Cursor fixture output improved (correct labels, no false warnings, correct budget)
- [x] Mixed setup (Claude + Cursor) works correctly