### PR TITLE
docs: change 'before pushing' to 'before committing' in contribution guides

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,9 +19,9 @@ Every PR that adds a feature, fixes a bug, or changes behavior must include a CH
 
 To cut a release: `uv run scripts/release.py minor` (or `patch`/`major`). This moves unreleased entries to a dated version, bumps pyproject.toml, commits, and tags.
 
-## Before pushing
+## Before committing
 
-The CI runs 4 jobs: lint, typecheck, test, dogfood. All must pass. Run this before pushing:
+The CI runs 4 jobs: lint, typecheck, test, dogfood. All must pass. Run this before committing:
 
 ```bash
 uv run ruff format src/ tests/ && uv run ruff check src/ tests/ && uv run pytest tests/ -q

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ The CI runs 4 jobs: lint, typecheck, test, dogfood. All must pass. Run this befo
 uv run ruff format src/ tests/ && uv run ruff check src/ tests/ && uv run pytest tests/ -q
 ```
 
-The most common CI failure is forgetting `ruff format`. The `ruff check` (lint rules) and `ruff format` (code style) are separate checks. Both must pass.
+All three must pass. The most common CI failure is forgetting `ruff format`. The `ruff check` (lint rules) and `ruff format` (code style) are separate checks.
 
 ## Project structure
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,14 +10,13 @@ uv sync --extra dev
 uv run pre-commit install
 ```
 
-## Before pushing
+## Before committing
 
 ```bash
-uv run ruff check src/ tests/
-uv run pytest tests/ -q
+uv run ruff format src/ tests/ && uv run ruff check src/ tests/ && uv run pytest tests/ -q
 ```
 
-Both must pass. Pre-commit hooks will also run automatically.
+All three must pass. Commits that fail `ruff check` will be rejected by pre-commit hooks.
 
 ## Adding a new inspection rule
 
@@ -181,7 +180,7 @@ Add a row to the Future Plans table in `README.md`.
 ## PR guidelines
 
 - One logical change per PR. Don't mix a new rule with a future plan rewrite.
-- Run `uv run ruff check src/ tests/` and `uv run pytest tests/ -q` before pushing.
+- Run `uv run ruff format src/ tests/ && uv run ruff check src/ tests/ && uv run pytest tests/ -q` before committing.
 - PR title should describe what changed, not how (e.g., "Add shadows-builtin rule" not "Add new file and update init").
 - If adding a rule, include the test in the same PR.
 - If adding a future plan, follow the structure above.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ uv run pre-commit install
 uv run ruff format src/ tests/ && uv run ruff check src/ tests/ && uv run pytest tests/ -q
 ```
 
-All three must pass. Commits that fail `ruff check` will be rejected by pre-commit hooks.
+All three must pass. Commits that fail `ruff check` or `ruff format` will be rejected by pre-commit hooks.
 
 ## Adding a new inspection rule
 


### PR DESCRIPTION
## Summary

- Changed "Before pushing" to "Before committing" in both CLAUDE.md and CONTRIBUTING.md
- Unified the lint command in CONTRIBUTING.md to include `ruff format` (was missing)
- Clarified that pre-commit hooks will reject commits that fail `ruff check`

## Why

The fullsend code agent reads these docs for repo conventions but doesn't push — the post-script does. The agent interpreted "Before pushing" as not its responsibility, skipping lint checks. This caused 3 consecutive failures on issue #9 where the agent committed code that violated `ruff check` rules.

## Test plan

- [ ] Re-trigger `/fs-code` on issue #9 after merge to verify the agent runs lint checks before committing

🤖 Generated with [Claude Code](https://claude.com/claude-code)