### PR TITLE
feat: add fuzzy matching for rule IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- Fuzzy matching for rule IDs: suppression comments, preset configs, and registry lookups now warn with "Did you mean?" suggestions when a rule ID doesn't match any registered rule
 - Tool-aware rule filtering: rules can declare `tools=("claude",)` or `tools=("cursor",)` to only run for matching components
 - `source_tool` field on `ParsedComponent` and `RuleContext` to track whether a component came from `.claude/` or `.cursor/`
 - Cursor-aware budget analysis: respects `alwaysApply` frontmatter in `.mdc` files instead of treating all Cursor rules as always-loaded

--- a/src/harness_eval_lab/inspection/engine.py
+++ b/src/harness_eval_lab/inspection/engine.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import re
 from collections.abc import Callable
 from pathlib import Path
@@ -15,7 +16,7 @@ from harness_eval_lab.inspection.parsers import (
     parse_hooks,
     parse_skill,
 )
-from harness_eval_lab.inspection.registry import get_all_rules
+from harness_eval_lab.inspection.registry import get_all_rules, suggest_rule_id
 from harness_eval_lab.inspection.suppression import is_suppressed, parse_suppressions
 from harness_eval_lab.inspection.types import (
     Finding,
@@ -30,6 +31,8 @@ from harness_eval_lab.inspection.types import (
     RuleResult,
     Severity,
 )
+
+logger = logging.getLogger(__name__)
 
 _INTERPOLATION_RE = re.compile(r"\{\{(\w+)\}\}")
 
@@ -161,7 +164,7 @@ def _run_rules(
     findings: list[Finding] = []
     rules_run: list[RuleResult] = []
     suppression_counter = [0]
-    suppressions = parse_suppressions(raw_content) if raw_content else {}
+    suppressions = parse_suppressions(raw_content, file_path=file_path) if raw_content else {}
     config_rules = config_rules or {}
     scan_state = scan_state if scan_state is not None else {}
 
@@ -509,12 +512,36 @@ def lint_text_file(
     )
 
 
+_warned_config_rules: set[str] = set()
+
+
+def _warn_unknown_config_rules(config_rules: dict[str, str | list[Any]]) -> None:
+    """Log warnings for rule IDs in config that don't match any registered rule."""
+    all_rule_ids = {r.meta.id for r in get_all_rules()}
+    for rule_id in config_rules:
+        if rule_id in all_rule_ids or rule_id in _warned_config_rules:
+            continue
+        _warned_config_rules.add(rule_id)
+        suggestions = suggest_rule_id(rule_id)
+        if suggestions:
+            logger.warning(
+                "Config references unknown rule '%s'. Did you mean: %s?",
+                rule_id,
+                ", ".join(suggestions),
+            )
+        else:
+            logger.warning("Config references unknown rule '%s'.", rule_id)
+
+
 def inspect_setup(
     setup: Any,
     config_rules: dict[str, str | list[Any]] | None = None,
 ) -> list[InspectionResult]:
     """Run inspection on all components in a setup."""
     from harness_eval_lab.core.types import ComponentType as CT
+
+    if config_rules:
+        _warn_unknown_config_rules(config_rules)
 
     scan_state: dict[str, Any] = {}
     results: list[InspectionResult] = []

--- a/src/harness_eval_lab/inspection/registry.py
+++ b/src/harness_eval_lab/inspection/registry.py
@@ -1,6 +1,11 @@
 from __future__ import annotations
 
+import logging
+from difflib import get_close_matches
+
 from harness_eval_lab.inspection.types import Rule, RuleCategory
+
+logger = logging.getLogger(__name__)
 
 _registry: dict[str, Rule] = {}
 
@@ -21,6 +26,11 @@ def get_rules_by_category(category: RuleCategory) -> list[Rule]:
 
 def get_rule(rule_id: str) -> Rule | None:
     return _registry.get(rule_id)
+
+
+def suggest_rule_id(rule_id: str) -> list[str]:
+    """Return similar rule IDs for a non-matching ID."""
+    return get_close_matches(rule_id, _registry.keys(), n=3, cutoff=0.6)
 
 
 def clear_rules() -> None:

--- a/src/harness_eval_lab/inspection/suppression.py
+++ b/src/harness_eval_lab/inspection/suppression.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+import logging
 import re
+
+logger = logging.getLogger(__name__)
 
 _FILE_WIDE_RE = re.compile(r"<!--\s*evaluator-ignore:\s*([\w/,\s-]+)\s*-->", re.IGNORECASE)
 _NEXT_LINE_RE = re.compile(
@@ -8,7 +11,10 @@ _NEXT_LINE_RE = re.compile(
 )
 
 
-def parse_suppressions(raw_content: str) -> dict[int | None, set[str]]:
+def parse_suppressions(
+    raw_content: str,
+    file_path: str = "",
+) -> dict[int | None, set[str]]:
     """Parse suppression comments from skill content.
 
     Returns a dict mapping:
@@ -17,12 +23,14 @@ def parse_suppressions(raw_content: str) -> dict[int | None, set[str]]:
     """
     suppressions: dict[int | None, set[str]] = {}
     lines = raw_content.split("\n")
+    unknown_ids: list[str] = []
 
     for i, line in enumerate(lines):
         file_match = _FILE_WIDE_RE.search(line)
         if file_match:
             rule_ids = {r.strip() for r in file_match.group(1).split(",")}
             suppressions.setdefault(None, set()).update(rule_ids)
+            unknown_ids.extend(rule_ids)
             continue
 
         next_line_match = _NEXT_LINE_RE.search(line)
@@ -30,8 +38,35 @@ def parse_suppressions(raw_content: str) -> dict[int | None, set[str]]:
             rule_ids = {r.strip() for r in next_line_match.group(1).split(",")}
             target_line = i + 2  # 1-indexed, next line
             suppressions.setdefault(target_line, set()).update(rule_ids)
+            unknown_ids.extend(rule_ids)
+
+    _warn_unknown_rule_ids(unknown_ids, file_path)
 
     return suppressions
+
+
+def _warn_unknown_rule_ids(rule_ids: list[str], file_path: str) -> None:
+    """Log warnings for suppressed rule IDs that don't match any registered rule."""
+    from harness_eval_lab.inspection.registry import get_rule, suggest_rule_id
+
+    for rule_id in rule_ids:
+        if get_rule(rule_id) is not None:
+            continue
+        suggestions = suggest_rule_id(rule_id)
+        location = f" in {file_path}" if file_path else ""
+        if suggestions:
+            logger.warning(
+                "Suppression references unknown rule '%s'%s. Did you mean: %s?",
+                rule_id,
+                location,
+                ", ".join(suggestions),
+            )
+        else:
+            logger.warning(
+                "Suppression references unknown rule '%s'%s.",
+                rule_id,
+                location,
+            )
 
 
 def is_suppressed(


### PR DESCRIPTION
Suppression comments with typos (e.g. `security/no-credental-access`) previously did nothing with no warning. Same for preset configs referencing mistyped rule IDs.\n\nThis adds fuzzy matching using `difflib.get_close_matches` at three points:\n\n- **registry.py**: new `suggest_rule_id()` function\n- **suppression.py**: warns when suppressed rule IDs don't match any registered rule\n- **engine.py**: warns when preset config references unknown rule IDs\n\nAll warnings include suggestions: \"Did you mean: security/no-credential-access?\"\n\nNo changes to CLI flags, output formats, or plugin skills. Warnings go through Python logging.\n\n188 tests pass."