### PR TITLE
fix: sync plugin manifest versions and rule count

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "setup-eval",
       "source": "./",
-      "version": "3.3.0",
+      "version": "3.5.0",
       "description": "Evaluate AI agent setups for best practices, redundancy, security, and cross-component issues. 43 lint rules, per-component rubric review, deep security audit, and single-skill evaluation."
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "setup-eval",
   "displayName": "Setup Eval",
-  "version": "3.3.0",
+  "version": "3.5.0",
   "description": "Evaluate AI agent setups for best practices, redundancy, security, and cross-component issues.",
   "author": {
     "name": "Benjamin Kapner"

--- a/commands/setup-eval-lint.md
+++ b/commands/setup-eval-lint.md
@@ -1,5 +1,5 @@
 ---
-description: "Run deterministic static analysis on the full agent setup (CLAUDE.md, skills, commands, hooks, agents, MCP configs). 39 rules + system-level analysis. No LLM, fast, CI-suitable."
+description: "Run deterministic static analysis on the full agent setup (CLAUDE.md, skills, commands, hooks, agents, MCP configs). 43 rules + system-level analysis. No LLM, fast, CI-suitable."
 ---
 
 # Eval Setup Lint

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -26,6 +26,10 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parent.parent
 PYPROJECT = ROOT / "pyproject.toml"
 CHANGELOG = ROOT / "CHANGELOG.md"
+PLUGIN_MANIFESTS = [
+    ROOT / ".claude-plugin" / "marketplace.json",
+    ROOT / ".claude-plugin" / "plugin.json",
+]
 
 
 def read_current_version() -> str:
@@ -115,6 +119,23 @@ def update_changelog(new_version: str, dry_run: bool) -> bool:
     return True
 
 
+def update_plugin_manifests(new_version: str, dry_run: bool) -> None:
+    for manifest in PLUGIN_MANIFESTS:
+        if not manifest.exists():
+            continue
+        text = manifest.read_text()
+        updated = re.sub(
+            r'"version"\s*:\s*"[^"]+"',
+            f'"version": "{new_version}"',
+            text,
+            count=1,
+        )
+        if dry_run:
+            print(f"  [dry-run] Would update {manifest.name} version to {new_version}")
+            continue
+        manifest.write_text(updated)
+
+
 def git_commit_and_tag(new_version: str, dry_run: bool) -> None:
     tag = f"v{new_version}"
     msg = f"release: {tag}"
@@ -124,8 +145,13 @@ def git_commit_and_tag(new_version: str, dry_run: bool) -> None:
         print(f"  [dry-run] Would create tag: {tag}")
         return
 
+    files_to_add = [str(PYPROJECT), str(CHANGELOG)]
+    for manifest in PLUGIN_MANIFESTS:
+        if manifest.exists():
+            files_to_add.append(str(manifest))
+
     subprocess.run(
-        ["git", "add", str(PYPROJECT), str(CHANGELOG)],
+        ["git", "add", *files_to_add],
         cwd=ROOT,
         check=True,
     )
@@ -140,7 +166,7 @@ def git_commit_and_tag(new_version: str, dry_run: bool) -> None:
         check=True,
     )
     print(f"\n  Committed and tagged {tag}.")
-    print(f"  Push with: git push origin main --tags")
+    print("  Push with: git push origin main --tags")
 
 
 def main() -> None:
@@ -165,14 +191,17 @@ def main() -> None:
     print("2. Updating CHANGELOG.md...")
     changelog_updated = update_changelog(new_version, args.dry_run)
 
+    print("3. Updating plugin manifests...")
+    update_plugin_manifests(new_version, args.dry_run)
+
     if not changelog_updated and not args.dry_run:
         print("\n  Warning: No changelog entries moved. Consider adding entries before releasing.")
 
     if not args.no_commit:
-        print("3. Committing and tagging...")
+        print("4. Committing and tagging...")
         git_commit_and_tag(new_version, args.dry_run)
     else:
-        print("3. Skipping git commit/tag (--no-commit).")
+        print("4. Skipping git commit/tag (--no-commit).")
 
     print("\nDone.")
 

--- a/skills/setup-eval-lint/SKILL.md
+++ b/skills/setup-eval-lint/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: setup-eval-lint
-description: Run deterministic static analysis on the full agent setup (CLAUDE.md, skills, commands, hooks, agents, MCP configs). 39 rules + system-level analysis (token budget, trigger overlaps, dependencies, context utilization). No LLM. Use when the user wants a fast lint check, CI gate, or structural health report.
+description: Run deterministic static analysis on the full agent setup (CLAUDE.md, skills, commands, hooks, agents, MCP configs). 43 rules + system-level analysis (token budget, trigger overlaps, dependencies, context utilization). No LLM. Use when the user wants a fast lint check, CI gate, or structural health report.
 allowed-tools:
   - Bash
   - Read

--- a/skills/setup-eval-review/report-format.md
+++ b/skills/setup-eval-review/report-format.md
@@ -23,7 +23,7 @@ Always start the report with this exact text (hardcoded, do not modify):
 
 This review combines two passes:
 
-**Lint (deterministic)** runs 39 rules checking structure, frontmatter, token budget,
+**Lint (deterministic)** runs 43 rules checking structure, frontmatter, token budget,
 broken references, duplicate detection, security patterns (injection, credentials,
 exfiltration, obfuscation, reverse shells), AST behavioral analysis, taint tracking,
 MCP permission analysis, and tool poisoning detection.

--- a/src/harness_eval_lab/cli.py
+++ b/src/harness_eval_lab/cli.py
@@ -54,7 +54,7 @@ def eval_setup_lint(
     watch: bool,
     user_config: str | None,
 ) -> None:
-    """Lint: 39 rules + system analysis. No LLM, deterministic, fast."""
+    """Lint: 43 rules + system analysis. No LLM, deterministic, fast."""
     if watch:
         from harness_eval_lab.watch import run_watch
 

--- a/tests/test_version_consistency.py
+++ b/tests/test_version_consistency.py
@@ -1,0 +1,36 @@
+"""Test that version strings are consistent across all distribution artifacts."""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def _read_pyproject_version() -> str:
+    text = (ROOT / "pyproject.toml").read_text()
+    match = re.search(r'^version\s*=\s*"(.+?)"', text, re.MULTILINE)
+    assert match, "Could not find version in pyproject.toml"
+    return match.group(1)
+
+
+def test_marketplace_json_version_matches_pyproject() -> None:
+    expected = _read_pyproject_version()
+    marketplace = json.loads((ROOT / ".claude-plugin" / "marketplace.json").read_text())
+    actual = marketplace["plugins"][0]["version"]
+    assert actual == expected, (
+        f"marketplace.json version ({actual}) does not match "
+        f"pyproject.toml ({expected}). Run: uv run scripts/release.py"
+    )
+
+
+def test_plugin_json_version_matches_pyproject() -> None:
+    expected = _read_pyproject_version()
+    plugin = json.loads((ROOT / ".claude-plugin" / "plugin.json").read_text())
+    actual = plugin["version"]
+    assert actual == expected, (
+        f"plugin.json version ({actual}) does not match "
+        f"pyproject.toml ({expected}). Run: uv run scripts/release.py"
+    )


### PR DESCRIPTION
### Problem\n\nPlugin manifests (`marketplace.json`, `plugin.json`) were stuck at version 3.3.0 while `pyproject.toml` was at 3.5.0. The `release.py` script only bumps `pyproject.toml` and `CHANGELOG.md`, so every release since 3.3.0 left the plugin manifests stale.\n\nSeparately, the rule count drifted: Claude Code skill/command/CLI said \"39 rules\" while the actual count is 43 (confirmed via registry). The Cursor command already had the correct count.\n\n### Changes\n\n**Version sync:**\n- Updated `marketplace.json` and `plugin.json` to 3.5.0\n- Updated `release.py` to bump plugin manifest versions alongside `pyproject.toml` and `CHANGELOG.md`\n- Added `test_version_consistency.py` that asserts all three files have matching versions (catches future drift in CI)\n\n**Rule count:**\n- Updated from 39 to 43 in: CLI help text, `SKILL.md`, `command.md`, `report-format.md`\n\n### Test plan\n\n- [x] 228 tests pass (including 2 new version consistency tests)\n- [x] `ruff check` and `ruff format --check` pass\n- [x] `release.py --dry-run` shows plugin manifest update step