### PR TITLE
security: supply chain hardening and path traversal fixes (v3.6.2)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "setup-eval",
       "source": "./",
-      "version": "3.6.1",
+      "version": "3.6.2",
       "description": "Evaluate AI agent setups for best practices, redundancy, security, and cross-component issues. 43 lint rules, per-component rubric review, deep security audit, and single-skill evaluation."
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "setup-eval",
   "displayName": "Setup Eval",
-  "version": "3.6.1",
+  "version": "3.6.2",
   "description": "Evaluate AI agent setups for best practices, redundancy, security, and cross-component issues.",
   "author": {
     "name": "Benjamin Kapner"

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,7 @@
-* @Benkapner
+# Default: both maintainers must review
+* @Benkapner @csoceanu
+
+# Release-critical files require both maintainers
+pyproject.toml @Benkapner @csoceanu
+.github/workflows/publish.yml @Benkapner @csoceanu
+scripts/release.py @Benkapner @csoceanu

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,3 +5,14 @@ repos:
       - id: ruff
         args: [--fix]
       - id: ruff-format
+
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.21.2
+    hooks:
+      - id: gitleaks
+
+  - repo: https://github.com/PyCQA/bandit
+    rev: "1.8.3"
+    hooks:
+      - id: bandit
+        args: ["-r", "src/"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- Path traversal protection: `safe_join()` and `is_within()` utilities prevent file references and auto-fixes from escaping the project directory
+- 12 tests for path safety covering traversal, symlink escape, and absolute path injection
+- Gitleaks and Bandit pre-commit hooks for secret scanning and Python security analysis
+- Incident response plan in SECURITY.md (contain, assess, yank, notify, remediate, post-mortem)
+- Privacy and data handling section in README documenting what each command sends externally
+- Dual CODEOWNERS: both @Benkapner and @csoceanu required for review, with stricter rules for release-critical files
+
+### Fixed
+- Broken references rule now rejects path traversal attempts instead of following them
+- Command script-exists rule now rejects path traversal in script references
+- Auto-fixer validates file paths stay within project root before writing
+
 ## [3.6.1] - 2026-06-26
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [3.6.2] - 2026-06-29
+
 ### Added
 - Path traversal protection: `safe_join()` and `is_within()` utilities prevent file references and auto-fixes from escaping the project directory
 - 12 tests for path safety covering traversal, symlink escape, and absolute path injection

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ All notable changes to this project will be documented in this file.
 - Gitleaks and Bandit pre-commit hooks for secret scanning and Python security analysis
 - Incident response plan in SECURITY.md (contain, assess, yank, notify, remediate, post-mortem)
 - Privacy and data handling section in README documenting what each command sends externally
-- CODEOWNERS: both @Benkapner and @csoceanu are requested as reviewers, with stricter ownership rules for release-critical files
+- CODEOWNERS: both @Benkapner and @csoceanu required for review (2 approvals), with stricter ownership rules for release-critical files
 
 ### Fixed
 - Broken references rule now rejects path traversal attempts instead of following them

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ All notable changes to this project will be documented in this file.
 - Gitleaks and Bandit pre-commit hooks for secret scanning and Python security analysis
 - Incident response plan in SECURITY.md (contain, assess, yank, notify, remediate, post-mortem)
 - Privacy and data handling section in README documenting what each command sends externally
-- Dual CODEOWNERS: both @Benkapner and @csoceanu required for review, with stricter rules for release-critical files
+- CODEOWNERS: both @Benkapner and @csoceanu are requested as reviewers, with stricter ownership rules for release-critical files
 
 ### Fixed
 - Broken references rule now rejects path traversal attempts instead of following them

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,7 @@ All three must pass. The most common CI failure is forgetting `ruff format`. The
   - `rubric/` - LLM-based issue detection; prompts in `rubric/prompts/`
   - `analysis/` - system-level analysis (budget, triggers, dependencies, context utilization)
   - `output/` - report generation (terminal + JSON)
-  - `utils/` - token counting, TF-IDF similarity, frontmatter parsing, LLM client
+  - `utils/` - token counting, TF-IDF similarity, frontmatter parsing, LLM client, path safety
 - `skills/` - plugin skills with SKILL.md + rubric files + scripts
 - `tests/` - pytest test suite with fixtures
 - `future-plans/` - planned improvements in structured spec format
@@ -55,3 +55,4 @@ All three must pass. The most common CI failure is forgetting `ruff format`. The
 - LLM prompts live in `src/harness_eval_lab/rubric/prompts/` as markdown files, not inline strings
 - `skills/eval-skill/rubric/skills-rubric.md` is a symlink to `skills/setup-eval-review/rubric/skills-rubric.md`; edit the source, not the link
 - YARA and CVE rules only run in the `security` preset (used by `setup-eval-security`), never in lint
+- Rules that resolve file paths from user content must use `safe_join()` from `utils.paths` to prevent path traversal; never join untrusted paths with raw `/` or `Path()`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,6 +18,8 @@ uv run ruff format src/ tests/ && uv run ruff check src/ tests/ && uv run pytest
 
 All three must pass. Commits that fail `ruff check` or `ruff format` will be rejected by pre-commit hooks.
 
+Pre-commit also runs **gitleaks** (secret scanning) and **bandit** (Python security analysis). If gitleaks blocks your commit, you likely have a hardcoded credential or API key that needs to be moved to an environment variable.
+
 ## Adding a new inspection rule
 
 A rule is a Python class that checks one specific thing about one component type. Each rule lives in its own file.

--- a/README.md
+++ b/README.md
@@ -96,6 +96,23 @@ No API key needed for review/security/skill. Cursor evaluates in-session.
 
 Four presets: `recommended` (default), `strict`, `security`, `pre-workflow`.
 
+## Privacy and Data Handling
+
+`setup-eval` reads files from your project directory to analyze your AI agent setup. Here is what happens with your data in each mode:
+
+| Command | Sends data externally? | What is sent | Where |
+|---------|----------------------|--------------|-------|
+| `setup-eval-lint` | No | Nothing. Fully offline. | N/A |
+| `setup-eval-review` | Yes (CLI only) | Code snippets from your setup files | Gemini or Anthropic API (your choice via `--provider`) |
+| `setup-eval-security` | Scan: No. `--review`: Yes (CLI only) | Code snippets from flagged files | Gemini or Anthropic API |
+| `eval-skill` | Lint: No. `--rubric`: Yes (CLI only) | The skill content being evaluated | Gemini or Anthropic API |
+
+When used as a **Claude Code plugin**, review/security/eval-skill commands use the existing Claude session. No additional API calls are made.
+
+When used as **Cursor commands**, the evaluation happens in the Cursor session. No additional API calls are made.
+
+**File access:** The tool only reads files within the project directory you point it at. Path traversal protections prevent reading files outside the project boundary.
+
 ## Contributing
 
 See [`CONTRIBUTING.md`](CONTRIBUTING.md) for adding rules and submitting PRs.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,3 +7,59 @@ If you discover a security vulnerability in setup-eval, please report it by emai
 Include description of the vulnerability, steps to reproduce and impact assessment (what an attacker could do)
 
 We will work with you to understand the issue and coordinate a fix
+
+## Incident Response Plan
+
+If a compromise is detected (malicious code in a release, compromised credentials, unauthorized repository access), follow these steps in order:
+
+### 1. Contain
+
+- Immediately **revoke** any compromised credentials (GitHub PATs, PyPI tokens, API keys)
+- **Lock the repository** temporarily if unauthorized pushes occurred (Settings > Moderation > Interaction limits)
+- Disable the publish workflow to prevent further releases (`gh workflow disable publish.yml`)
+
+### 2. Assess
+
+- Identify which releases are affected by reviewing git history and tags
+- Determine the attack vector (compromised machine, stolen credentials, supply chain dependency)
+- Check the audit log: `gh api orgs/redhat-community-ai-tools/audit-log --paginate`
+- Review recent CI runs for unexpected behavior
+
+### 3. Yank Affected Releases
+
+- **PyPI:** yank compromised versions (does not delete, but hides from default installs):
+  ```bash
+  # For each affected version:
+  pip install twine
+  twine upload --skip-existing --repository pypi --comment "Security issue" ...
+  # Or via PyPI web UI: go to the release > Options > Yank
+  ```
+- **Claude Code plugin marketplace:** contact the marketplace team to delist the compromised version
+- **GitHub releases:** mark affected releases as pre-release and add a warning to the release notes
+
+### 4. Notify Users
+
+- Create a **GitHub Security Advisory** on the repository (Security tab > Advisories > New)
+- Post a notice in the README (temporary banner at the top)
+- Email known enterprise users if applicable
+- Include in the advisory:
+  - Which versions are affected
+  - What the impact is (what the attacker could access/do)
+  - What users should do (upgrade, rotate credentials, audit)
+  - A safe version to pin to
+
+### 5. Remediate
+
+- Fix the vulnerability and release a patched version
+- Rotate all credentials:
+  - GitHub deploy keys and PATs
+  - PyPI API tokens (regenerate via Trusted Publishing)
+  - Any API keys (Gemini, Anthropic) used in CI
+- Review and tighten access controls (see branch protection and CODEOWNERS)
+- Update the security advisory with the fix version
+
+### 6. Post-Incident
+
+- Write a post-mortem documenting the timeline, root cause, and actions taken
+- Review whether additional security controls would have prevented the incident
+- Update this incident response plan with lessons learned

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "setup-eval"
-version = "3.6.1"
+version = "3.6.2"
 description = "Evaluate and compare AI agent setups through experiments, inspections, and rubric scoring."
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/harness_eval_lab/cli.py
+++ b/src/harness_eval_lab/cli.py
@@ -191,7 +191,7 @@ def eval_setup_lint(
 
     if fix:
         all_findings = [d for r in results for d in r.diagnostics]
-        fix_results = apply_fixes(all_findings)
+        fix_results = apply_fixes(all_findings, project_root=Path(path).resolve())
         for fr in fix_results:
             click.echo(f"Fixed {fr.fixes_applied} issues in {fr.file_path}")
 

--- a/src/harness_eval_lab/inspection/fixer.py
+++ b/src/harness_eval_lab/inspection/fixer.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from harness_eval_lab.inspection.types import Finding
+from harness_eval_lab.utils.paths import is_within
 
 
 @dataclass
@@ -13,7 +14,7 @@ class FixResult:
     rule_ids: list[str]
 
 
-def apply_fixes(diagnostics: list[Finding]) -> list[FixResult]:
+def apply_fixes(diagnostics: list[Finding], project_root: Path | None = None) -> list[FixResult]:
     """Apply auto-fixes for diagnostics that have fix information.
 
     Groups fixes by file, applies in reverse line order to preserve line numbers.
@@ -30,6 +31,8 @@ def apply_fixes(diagnostics: list[Finding]) -> list[FixResult]:
     for file_path, diags in by_file.items():
         path = Path(file_path)
         if not path.exists():
+            continue
+        if project_root is not None and not is_within(path, project_root):
             continue
 
         content = path.read_text()

--- a/src/harness_eval_lab/inspection/rules/commands/script_exists.py
+++ b/src/harness_eval_lab/inspection/rules/commands/script_exists.py
@@ -11,6 +11,7 @@ from harness_eval_lab.inspection.types import (
     RuleMeta,
     Severity,
 )
+from harness_eval_lab.utils.paths import safe_join
 
 
 class CommandScriptExists:
@@ -39,8 +40,8 @@ class CommandScriptExists:
                 continue
             checked.add(script)
 
-            script_path = cmd_dir / script
-            if not script_path.exists():
+            script_path = safe_join(cmd_dir, script)
+            if script_path is None or not script_path.exists():
                 context.report(
                     ReportDescriptor(
                         message_id="missing_script",

--- a/src/harness_eval_lab/inspection/rules/content/broken_references.py
+++ b/src/harness_eval_lab/inspection/rules/content/broken_references.py
@@ -11,6 +11,7 @@ from harness_eval_lab.inspection.types import (
     RuleMeta,
     Severity,
 )
+from harness_eval_lab.utils.paths import safe_join
 
 _FILE_REF_PATTERNS = [
     re.compile(r"\[.*?\]\(([^)]+)\)"),  # markdown links [text](path)
@@ -76,8 +77,8 @@ class BrokenReferences:
                         continue
                     checked.add(ref)
 
-                    ref_path = skill_dir / ref
-                    if not ref_path.exists():
+                    ref_path = safe_join(skill_dir, ref)
+                    if ref_path is None or not ref_path.exists():
                         context.report(
                             ReportDescriptor(
                                 message_id="broken_ref",

--- a/src/harness_eval_lab/utils/paths.py
+++ b/src/harness_eval_lab/utils/paths.py
@@ -1,0 +1,35 @@
+"""Path validation utilities to prevent path traversal attacks."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def is_within(path: Path, root: Path) -> bool:
+    """Check that path resolves to a location within root.
+
+    Resolves symlinks before checking. Returns False if the resolved
+    path escapes root or if the path does not exist and contains '..'
+    components that would escape.
+    """
+    try:
+        resolved = path.resolve()
+        resolved_root = root.resolve()
+        return resolved.is_relative_to(resolved_root)
+    except (OSError, ValueError):
+        return False
+
+
+def safe_join(root: Path, untrusted: str) -> Path | None:
+    """Join an untrusted relative path to a root, returning None if it escapes.
+
+    Does NOT require the path to exist (for checking references that may be broken).
+    Normalizes '..' components and checks the result stays within root.
+    """
+    if not untrusted or untrusted.startswith("/"):
+        return None
+    candidate = (root / untrusted).resolve()
+    resolved_root = root.resolve()
+    if candidate.is_relative_to(resolved_root):
+        return candidate
+    return None

--- a/tests/test_path_safety.py
+++ b/tests/test_path_safety.py
@@ -2,8 +2,6 @@
 
 from pathlib import Path
 
-import pytest
-
 from harness_eval_lab.utils.paths import is_within, safe_join
 
 

--- a/tests/test_path_safety.py
+++ b/tests/test_path_safety.py
@@ -1,0 +1,68 @@
+"""Tests for path traversal prevention."""
+
+from pathlib import Path
+
+import pytest
+
+from harness_eval_lab.utils.paths import is_within, safe_join
+
+
+class TestIsWithin:
+    def test_child_path(self, tmp_path: Path) -> None:
+        child = tmp_path / "subdir" / "file.txt"
+        child.parent.mkdir(parents=True)
+        child.touch()
+        assert is_within(child, tmp_path) is True
+
+    def test_same_path(self, tmp_path: Path) -> None:
+        assert is_within(tmp_path, tmp_path) is True
+
+    def test_parent_escapes(self, tmp_path: Path) -> None:
+        escaped = tmp_path / ".." / ".." / "etc" / "passwd"
+        assert is_within(escaped, tmp_path) is False
+
+    def test_symlink_escape(self, tmp_path: Path) -> None:
+        target = Path("/tmp")
+        link = tmp_path / "escape_link"
+        link.symlink_to(target)
+        assert is_within(link, tmp_path) is False
+
+    def test_symlink_within(self, tmp_path: Path) -> None:
+        target = tmp_path / "real_file.txt"
+        target.touch()
+        link = tmp_path / "link_file.txt"
+        link.symlink_to(target)
+        assert is_within(link, tmp_path) is True
+
+
+class TestSafeJoin:
+    def test_simple_relative(self, tmp_path: Path) -> None:
+        (tmp_path / "scripts").mkdir()
+        (tmp_path / "scripts" / "run.sh").touch()
+        result = safe_join(tmp_path, "scripts/run.sh")
+        assert result is not None
+        assert result == (tmp_path / "scripts" / "run.sh").resolve()
+
+    def test_traversal_blocked(self, tmp_path: Path) -> None:
+        result = safe_join(tmp_path, "../../etc/passwd")
+        assert result is None
+
+    def test_absolute_path_blocked(self, tmp_path: Path) -> None:
+        result = safe_join(tmp_path, "/etc/passwd")
+        assert result is None
+
+    def test_empty_string_blocked(self, tmp_path: Path) -> None:
+        result = safe_join(tmp_path, "")
+        assert result is None
+
+    def test_dotdot_in_middle(self, tmp_path: Path) -> None:
+        result = safe_join(tmp_path, "scripts/../../../etc/passwd")
+        assert result is None
+
+    def test_nonexistent_but_safe(self, tmp_path: Path) -> None:
+        result = safe_join(tmp_path, "does/not/exist.txt")
+        assert result is not None
+
+    def test_hidden_ssh_traversal(self, tmp_path: Path) -> None:
+        result = safe_join(tmp_path, "../../.ssh/id_rsa")
+        assert result is None


### PR DESCRIPTION
## Summary

Supply chain security hardening based on review with a cybersecurity expert. Addresses path traversal vulnerabilities, adds incident response procedures, and hardens the development pipeline.

- **Path traversal protection:** new `safe_join()` and `is_within()` utilities in `utils/paths.py`, applied to broken references rule, script-exists rule, and auto-fixer to prevent reading/writing files outside the project directory
- **Incident response plan** in SECURITY.md: 6-step procedure (contain, assess, yank, notify, remediate, post-mortem)
- **Pre-commit security hooks:** gitleaks (secret scanning) and bandit (Python security analysis)
- **CODEOWNERS:** both @Benkapner and @csoceanu required for review (2 approvals), stricter rules for release-critical files (pyproject.toml, publish.yml, release.py)
- **Privacy/data handling section** in README documenting what each command sends externally
- **12 new tests** for path safety covering traversal, symlink escape, and absolute path injection
- Version bump to 3.6.2

## Companion manual steps (already done)

- Branch protection on `main`: 2 required approvals, required status checks (lint, typecheck, test, dogfood), conversation resolution, block force pushes
- Tag protection rule for `v*` (restricts release tag creation)

## Test plan

- [x] All 257 tests pass (including 12 new path safety tests)
- [x] `ruff check` passes
- [x] `ruff format` passes
- [ ] CI pipeline passes (lint, typecheck, test, dogfood)
- [ ] Verify gitleaks and bandit hooks work locally: `uv run pre-commit run --all-files`