### PR TITLE
feat: add quality lint rules for instruction effectiveness

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "setup-eval",
       "source": "./",
-      "version": "3.6.2",
+      "version": "3.7.0",
       "description": "Evaluate AI agent setups for best practices, redundancy, security, and cross-component issues. 43 lint rules, per-component rubric review, deep security audit, and single-skill evaluation."
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "setup-eval",
   "displayName": "Setup Eval",
-  "version": "3.6.2",
+  "version": "3.7.0",
   "description": "Evaluate AI agent setups for best practices, redundancy, security, and cross-component issues.",
   "author": {
     "name": "Benjamin Kapner"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [3.7.0] - 2026-06-29
+
+### Added
+- New `quality/` rule category with 5 lint rules for instruction effectiveness:
+  - `quality/imprecise-instruction`: detect hedging, passive voice, and vague conditions
+  - `quality/redundant-guidance`: detect instructions redundant with model defaults or project tooling config (.editorconfig, .prettierrc, .eslintrc, tsconfig.json, pyproject.toml)
+  - `quality/unfinished-content`: detect placeholders, TODO/FIXME markers, deferred content (TBD, coming soon), and empty markdown sections
+  - `quality/example-gap`: flag skills with many instructions but no code examples
+  - `quality/stale-references`: detect deprecated models (text-davinci, gpt-3.5-turbo, claude-v1/v2), sunset APIs, old runtimes (Node 14/16, Python 3.7/3.8), and outdated tools (tslint, create-react-app)
+- Shared pattern module `_patterns.py` for tautological detection across rules
+- 56 tests covering positive matches and false-positive prevention for all quality rules
+- Future plan spec for content intelligence Phase 2-3 rules
+
 ## [3.6.2] - 2026-06-29
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Four commands, same engine:
 
 | Command | What it does | LLM in CLI | LLM in Claude Code / Cursor |
 |---------|-------------|-----------|----------------------------|
-| `setup-eval-lint` | 43 deterministic rules + system analysis (token budget, trigger overlaps, dependencies). Fast, CI-suitable. | No | No |
+| `setup-eval-lint` | 48 deterministic rules + system analysis (token budget, trigger overlaps, dependencies). Fast, CI-suitable. | No | No |
 | `setup-eval-review` | Per-component rubric review with 0-3 scoring per dimension, 21 cross-type checks. KEEP/REVIEW/REMOVE verdicts. | Yes (API key) | Yes (in-session) |
 | `setup-eval-security` | All security rules + YARA + CVE lookups + semantic review. SAFE/CAUTION/UNSAFE. | Scan: no. Semantic review: `--review` flag | Yes (in-session) |
 | `eval-skill` | Deep-evaluate one skill individually and in context of the full setup. | Lint: no. Rubric: `--rubric` flag | Yes (in-session) |
@@ -80,13 +80,14 @@ Then copy `.cursor/commands/` from [this repo](https://github.com/redhat-communi
 
 No API key needed for review/security/skill. Cursor evaluates in-session.
 
-## Inspection Rules (43)
+## Inspection Rules (48)
 
 | Category | Rules | What they check |
 |----------|-------|-----------------|
 | Structural | 1 | SKILL.md exists |
 | Frontmatter | 3 | Description required/quality, format valid |
 | Content | 4 | Duplicate detection (TF-IDF), broken references, circular references, token budget |
+| Quality | 5 | Imprecise instructions (hedging, passive voice, vague conditions), redundant guidance (model defaults + tooling config), unfinished content (placeholders, empty sections, deferred markers), example gap, stale references |
 | Security | 9 | Credential access, prompt injection (17 patterns), data exfiltration, obfuscation, reverse shells, AST analysis, taint tracking, MCP least-privilege, tool poisoning |
 | Security (opt-in) | 2 | YARA signatures, CVE lookups via OSV.dev |
 | Commands | 8 | Description, script exists, duplicates, credentials, injection, skill overlap, shadows built-in, references nonexistent skill |

--- a/future-plans/content-intelligence/spec.md
+++ b/future-plans/content-intelligence/spec.md
@@ -1,0 +1,331 @@
+# Content Intelligence: Are These Instructions Actually Effective?
+
+**Status:** future
+**Created:** 2026-06-29
+
+## Problem
+
+A setup can pass every structural rule, every security check, and every metadata validation, while the instructions themselves are vague, redundant, or positioned where the model won't pay attention to them.
+
+The tool currently evaluates whether a setup is well-formed and safe. It does not evaluate whether the instructions will actually work well with an LLM. This is a blind spot: the setup looks correct on paper but underperforms at runtime because the instructions are poorly written, poorly organized, or say things the model already knows.
+
+This is the gap between structural correctness and instruction effectiveness.
+
+## Proposal
+
+A new category of deterministic lint rules under `quality/` that check instruction quality and effectiveness. No LLM required for detection. All rules are fast, CI-suitable, and heuristic-based (regex, position analysis, token counting, cross-component comparison).
+
+What makes these rules different from structural checks: structural rules ask "is this well-formed?" while quality rules ask "will the model actually follow this?" The answer depends on how instructions are phrased, where they're positioned, whether they contradict each other, and whether they add anything the model doesn't already know.
+
+### New rules
+
+#### 1. `quality/imprecise-instruction` (WARNING)
+
+Detect language that weakens instruction compliance. Three sub-categories:
+
+**a) Hedging:** Non-committal phrasing where the author clearly intends a firm instruction. Patterns: "try to", "if possible", "you might want to", "perhaps consider", "ideally you should", "it would be nice to".
+
+**b) Passive directives:** Instructions written in passive voice that obscure who should act. "Tests should be run before merging" is weaker than "Run tests before merging." The model has to infer that it is the actor. Patterns: "should be [verb]ed", "needs to be [verb]ed", "is expected to be", "are to be [verb]ed".
+
+**c) Conditional ambiguity:** Conditional instructions where the condition itself is vague. "If appropriate, refactor the code" leaves the model to decide what "appropriate" means. Contrast with "If the function exceeds 50 lines, refactor it" where the condition is testable. Patterns: "if needed", "if appropriate", "when relevant", "as necessary", "if applicable", "where suitable".
+
+**False-positive mitigation:**
+- Skip lines inside code blocks (fenced or indented)
+- Skip lines that are clearly examples or quoted text (lines starting with `>` or inside blockquotes)
+- Skip hedging words that appear as part of a described behavior, not an instruction (e.g., "The API will try to reconnect" describes system behavior, not an instruction to the agent)
+- For passive voice: only flag lines that contain an instruction verb (run, check, validate, create, update, use, add, remove, test, deploy, build, format, lint) in passive form. Don't flag descriptive passive voice ("the database is hosted on AWS")
+- For conditional ambiguity: only flag when the vague condition is the primary gating clause, not a parenthetical. "Refactor if appropriate" is flagged. "Use the standard pattern (adjusting as needed for edge cases)" is fine because "as needed" modifies a secondary clause
+
+**Implementation:** Multi-pass regex with context awareness. First pass identifies candidate lines (not in code blocks, not in blockquotes). Second pass classifies the type (hedging, passive, conditional). Third pass applies false-positive filters (is this descriptive text or an instruction?).
+
+**Example findings:**
+```
+WARNING  imprecise-instruction: Line 14: 'try to use TypeScript' — hedging weakens compliance. State directly: 'use TypeScript'
+WARNING  imprecise-instruction: Line 28: 'Tests should be run before merging' — passive voice obscures the actor. Use active: 'Run tests before merging'
+WARNING  imprecise-instruction: Line 41: 'Refactor if appropriate' — condition is too vague for the model to evaluate. Specify when.
+```
+
+#### 2. `quality/tautological` (WARNING)
+
+Detect instructions the model already follows by default, in skills, commands, and agents. This extends `claude-md/generic-advice` beyond CLAUDE.md to all component types, with a broader pattern set.
+
+Two layers of detection:
+
+**a) Direct tautology:** Explicit statements of default behavior. Patterns: "write tests for your code", "use descriptive variable names", "follow the DRY principle", "handle edge cases", "validate user input", "use proper error handling", "write readable code", "document your changes", "keep functions small", "separate concerns".
+
+**b) Implied tautology:** Instructions that describe standard professional practice without project-specific context. "Make sure your code compiles before committing" (the model won't commit code that doesn't compile). "Review your changes before submitting" (the model reviews its work by default).
+
+**Relationship to existing rules:** `claude-md/generic-advice` handles CLAUDE.md with 12 patterns. This rule targets skills, commands, and agents with a broader, deduplicated pattern set. The two rules share a base pattern list via a common module, extended per component type. The shared list avoids maintenance drift.
+
+**False-positive mitigation:**
+- Only flag when the instruction has no project-specific qualifier. "Write tests" is tautological. "Write tests using pytest with the fixtures in `tests/conftest.py`" is specific and useful.
+- Heuristic: if the flagged line also contains a file path, tool name, or project-specific term (detected via the component's frontmatter `name` field or referenced paths), skip it
+- Skip lines inside examples sections (under headings containing "example", "sample", "template")
+
+**Implementation:** Shared pattern module at `src/harness_eval_lab/inspection/rules/quality/_patterns.py` used by both this rule and `claude-md/generic-advice`. Each pattern is a `(label, regex, specificity_check)` tuple where `specificity_check` is an optional function that returns True if the line contains enough project-specific context to not be tautological.
+
+**Example finding:**
+```
+WARNING  tautological: Line 8: 'handle edge cases' — the model does this by default. Either remove or add project-specific detail.
+```
+
+#### 3. `quality/negative-only` (WARNING)
+
+Detect prohibitions without constructive alternatives. Goes beyond simple "don't/never" matching with two analysis levels:
+
+**a) Standalone prohibition:** A line with a negative keyword ("don't", "never", "avoid", "do not", "must not", "should not") where no positive alternative appears within a 4-line window after it. Positive signals: "instead", "use", "prefer", "rather", "alternative", a colon followed by a concrete noun/verb, or a code block.
+
+**b) Negation-heavy sections:** When a markdown section (heading-to-heading) has more than 60% of its instruction lines starting with negative keywords, flag the section. A section that's mostly "don't do X, don't do Y, don't do Z" is structurally unhelpful even if each prohibition has a local alternative.
+
+**False-positive mitigation:**
+- Don't flag negations in security-focused sections (under headings containing "security", "safety", "warning", "danger"). Security instructions are legitimately prohibitive.
+- Don't flag "do not" / "never" that appear in descriptions of expected behavior ("The system will never retry failed payments") vs instructions to the agent
+- Require the negative keyword to be at the start of a clause or sentence, not mid-sentence. "The function returns null, never undefined" describes behavior, not a prohibition.
+
+**Implementation:** Line-by-line scan with a lookahead window. Track negation ratio per section for the section-level check.
+
+**Example findings:**
+```
+WARNING  negative-only: Line 22: 'Never use SELECT *' has no positive alternative within 4 lines. Add what to do instead.
+WARNING  negative-only: Section '## Code Style' has 5/7 instruction lines starting with prohibitions. Reframe as positive guidance.
+```
+
+#### 4. `quality/attention-zone` (INFO)
+
+Detect critical instructions positioned where LLM attention is weakest. Based on the well-documented U-shaped attention pattern in transformer models: strong attention at the beginning and end of input, measurable degradation in the middle.
+
+**How it works:**
+
+Unlike a simple "middle third" heuristic, this rule uses a position-based risk score:
+
+1. Divide the file into 10 equal segments by line count
+2. Segments 1-2 (top 20%) and 9-10 (bottom 20%) are the "high attention" zone
+3. Segments 4-7 (middle 40%) are the "low attention" zone
+4. Segments 3 and 8 are transitional (not flagged)
+
+Only fires when ALL of these conditions are met:
+- The file is longer than 80 lines (short files don't have meaningful attention gradients)
+- The line contains an emphasis marker: words in ALL-CAPS that are instruction keywords (MUST, CRITICAL, NEVER, ALWAYS, IMPORTANT, REQUIRED, WARNING, ESSENTIAL), bold markdown (`**must**`), or admonition-style markers (`> **Note:**`)
+- The emphasis marker is part of an instruction, not a heading or example
+
+**Why this threshold design:** Attention degradation is gradual, not a cliff at the one-third mark. The 10-segment model avoids flagging content that's only slightly past the top section. The 80-line minimum prevents noise on typical short skills.
+
+**False-positive mitigation:**
+- Skip headings (lines starting with `#`), since headings provide their own structural salience
+- Skip lines inside code blocks
+- Skip files with fewer than 3 emphasis markers (if the whole file is critical, none of it is uniquely important)
+- Only flag when the critical instruction is NOT under a heading that itself contains emphasis. If the section heading is "## CRITICAL: Input Validation", the content under it inherits the heading's salience.
+
+**Example finding:**
+```
+INFO     attention-zone: Line 112: 'MUST validate all user input' is in the low-attention zone (segment 6/10 of 240-line file). Consider moving to the first or last 20% of the file.
+```
+
+#### 5. `quality/wall-of-text` (INFO)
+
+Warn when a markdown section is too dense for effective LLM processing. Two sub-checks:
+
+**a) Section length:** A markdown section (content between two headings of the same or higher level) exceeds 400 tokens without sub-headings. Threshold is configurable via rule options.
+
+**b) Instruction density:** A section contains more than 15 discrete instruction-like lines (lines starting with imperative verbs, numbered items, or list markers with action verbs) within 400 tokens. High-density instruction blocks overwhelm the model; it may follow the first few and lose track of the rest.
+
+**Why two sub-checks:** A 600-token narrative section with 3 instructions is too long but manageable (just needs sub-headings). A 400-token section with 25 tightly-packed instructions is a different problem, even if it's technically within length. Both need different fixes.
+
+**Implementation:** Parse markdown headings to identify sections. Count tokens using the existing `count_tokens()` utility. For density, scan for instruction-starting patterns (imperative verbs, numbered lists, `-`/`*` list items followed by a verb).
+
+**Example findings:**
+```
+INFO     wall-of-text: '## Development' section is ~720 tokens with no sub-headings. Break into smaller sections.
+INFO     wall-of-text: '## Rules' section has 22 instruction lines in ~380 tokens. Consider grouping related instructions under sub-headings.
+```
+
+#### 6. `quality/hook-candidate` (INFO)
+
+Detect prose instructions that describe deterministic, event-triggered actions better enforced as hooks.
+
+**What qualifies:** An instruction is a hook candidate when it describes:
+- A specific action (run a command, execute a script, check something)
+- Triggered by a specific event (before commit, after save, before push, on PR)
+- Expected to happen every time (indicated by "always", "make sure", "ensure", "every time", or imperative without qualification)
+
+**Pattern design:** Two-part matching: (1) an event trigger phrase ("before committing", "before pushing", "after every change", "before submitting", "before merging", "on every PR") AND (2) a command-like token in the same sentence (a tool name like `ruff`, `pytest`, `eslint`, `prettier`, a script path like `./scripts/`, or a shell-like pattern like `run ...`).
+
+Both parts must be present. "Before committing, think about the impact" has a trigger but no command (it's guidance, not a hook candidate). "Run ruff format" has a command but no trigger (it's a general instruction, not event-bound).
+
+**False-positive mitigation:**
+- Require both trigger AND command in the same sentence or adjacent lines
+- Skip instructions inside conditional blocks ("If you're making a large change, run tests before committing" is conditional guidance, not a universal enforcement candidate)
+- Skip when the instruction is already described as optional ("you may want to run X before committing")
+- Cross-check: if the setup already has a matching hook in `context.scan_state` (populated by `hooks/valid-structure`), skip the finding. No point suggesting a hook that already exists.
+
+**Example finding:**
+```
+INFO     hook-candidate: Line 31: 'Always run ruff format before committing' — consider converting to a pre-commit hook for reliable enforcement.
+```
+
+#### 7. `quality/placeholder-text` (WARNING)
+
+Detect unfilled template markers and scaffolding remnants.
+
+**Patterns (ordered by confidence):**
+
+- **High confidence:** `[INSERT ...]`, `[YOUR ...]`, `<your-...-here>`, `[PLACEHOLDER]`, `[FILL IN]`, `[CHANGE THIS]`, `[UPDATE THIS]`. These are almost certainly unfilled templates.
+- **Medium confidence:** `TODO:`, `FIXME:`, `XXX:`, `HACK:` (with colon, distinguishing from prose use of the word "todo"). These are unfinished items.
+- **Low confidence (suppressed by default):** `{{...}}` double-brace patterns, bracket-enclosed ALL-CAPS like `[PROJECT_NAME]`. These have high false-positive rates in files that legitimately use template syntax.
+
+**False-positive mitigation:**
+- Skip code blocks entirely (template syntax in code is intentional)
+- For TODO/FIXME: require the colon suffix to distinguish "TODO: add error handling" from "we need to decide the todo list format"
+- For bracket patterns: only flag `[ALL_CAPS_WITH_UNDERSCORES]` patterns that contain common placeholder words (YOUR, INSERT, PROJECT, NAME, DESCRIPTION, API, KEY, TOKEN, URL, PATH). Don't flag `[RFC 2119]` or `[Section 3.1]`.
+- For `{{...}}`: only flag in non-template files. If the file contains a Jinja/Handlebars import or the project has a templates directory, suppress. This sub-check is off by default (low confidence tier).
+
+**Implementation:** Layered regex with confidence tiers. High-confidence patterns always fire. Medium-confidence patterns fire unless suppressed. Low-confidence patterns are opt-in via rule options.
+
+**Example findings:**
+```
+WARNING  placeholder-text: Line 5: '[INSERT YOUR PROJECT DESCRIPTION]' looks like unfilled template text.
+WARNING  placeholder-text: Line 12: 'TODO: add deployment instructions' — unfinished template section.
+```
+
+#### 8. `quality/cross-component-conflict` (WARNING)
+
+Detect conflicting instructions across different components in the same setup. This is unique to multi-component analysis and leverages the existing `context.all_skills` and `context.scan_state` infrastructure.
+
+**How it works:**
+
+Phase 1 (extraction): As each component is scanned, extract "instruction fingerprints" from directive lines: normalized (topic, stance) pairs. For example, "Use tabs for indentation" becomes `(indentation, tabs)`. "Always use 2-space indentation" becomes `(indentation, 2-space)`. Store these in `context.scan_state`.
+
+Phase 2 (comparison): After all components are scanned, compare fingerprints across components. Flag when two components express opposing stances on the same topic.
+
+**Topics to track:** A curated list of common configuration domains where contradictions cause real problems:
+- Indentation (tabs vs spaces, 2 vs 4)
+- Quotes (single vs double)
+- Semicolons (use vs omit)
+- Trailing commas (use vs omit)
+- Naming convention (camelCase vs snake_case vs kebab-case)
+- Testing framework preferences
+- Import ordering
+- Error handling style (throw vs return error)
+- Logging approach
+
+**Why this matters:** When CLAUDE.md says "use 4-space indentation" and a skill says "use tabs", the model gets contradictory instructions. It will follow one and ignore the other, producing inconsistent output. Worse, which one it follows may vary between sessions. This is a common real-world problem when setups are assembled from multiple authors or templates.
+
+**False-positive mitigation:**
+- Only flag when both components are active in the same context. A skill scoped to "Python development" saying "use spaces" doesn't conflict with a skill scoped to "Go development" saying "use tabs."
+- Use the extracted topic list, not free-text similarity. Two components that both mention "indentation" aren't necessarily conflicting.
+- Require opposing stances, not just different wording. "Use 4-space indentation" and "Indent with 4 spaces" are the same stance, differently worded.
+
+**Implementation:** Topic extraction via keyword + pattern matching (not TF-IDF). Store in `scan_state["quality_fingerprints"]`. Comparison runs as a post-scan phase. This rule needs to run after all components are processed, so it uses a two-phase pattern: `create()` extracts and stores, a separate finalize step (or a final pseudo-component scan) does the comparison.
+
+**Example finding:**
+```
+WARNING  cross-component-conflict: CLAUDE.md says 'use 4-space indentation' (line 15) but skill 'python-dev' says 'use tabs' (line 8). Contradictory instructions produce inconsistent behavior.
+```
+
+## Where it lives
+
+- `src/harness_eval_lab/inspection/rules/quality/` (new directory, 8 rule files + shared patterns module)
+  - `_patterns.py` — shared pattern lists used by `quality/tautological` and `claude-md/generic-advice`
+  - `imprecise_instruction.py`
+  - `tautological.py`
+  - `negative_only.py`
+  - `attention_zone.py`
+  - `wall_of_text.py`
+  - `hook_candidate.py`
+  - `placeholder_text.py`
+  - `cross_component_conflict.py`
+- Rule IDs follow the `quality/` namespace
+- Category: `RuleCategory.CONTENT` (these are content checks, just a different dimension)
+- Tests: `tests/test_quality_rules.py` (one test class per rule, with positive matches and false-positive checks)
+
+## Preset configuration
+
+| Rule | recommended | strict | security | pre-workflow |
+|------|-------------|--------|----------|--------------|
+| `quality/imprecise-instruction` | warning | error | off | off |
+| `quality/tautological` | warning | error | off | off |
+| `quality/negative-only` | warning | error | off | off |
+| `quality/attention-zone` | info | warning | off | off |
+| `quality/wall-of-text` | info | warning | off | off |
+| `quality/hook-candidate` | info | info | off | off |
+| `quality/placeholder-text` | warning | error | off | off |
+| `quality/cross-component-conflict` | warning | error | off | off |
+
+All rules are `off` in the `security` and `pre-workflow` presets since they're about instruction quality, not safety or CI gating.
+
+## Implementation order
+
+**Phase 1 (highest value, most differentiated):**
+1. `quality/imprecise-instruction` — three sub-categories (hedging, passive, conditional ambiguity) with context-aware false-positive filters
+2. `quality/placeholder-text` — layered confidence tiers, straightforward implementation
+3. `quality/tautological` — shared pattern module with `claude-md/generic-advice`, specificity-check filter
+
+**Phase 2 (cross-component and structural):**
+4. `quality/cross-component-conflict` — unique multi-component analysis using scan_state
+5. `quality/negative-only` — windowed lookahead + section-level negation ratio
+
+**Phase 3 (position and density analysis):**
+6. `quality/attention-zone` — 10-segment attention model with emphasis marker detection
+7. `quality/wall-of-text` — section length + instruction density dual check
+8. `quality/hook-candidate` — two-part pattern (event trigger + command), cross-checked against existing hooks
+
+## Report appearance
+
+These rules appear in the standard inspection results, grouped by component type. No changes to the report format are needed.
+
+Terminal output example:
+```
+  Skills (8)
+  ────────────────────────────────────────────────────────
+    deploy-skill                             3 warnings
+      WARNING  imprecise-instruction: 3 findings
+               Line 14: 'try to use TypeScript' — hedging weakens compliance
+               Line 28: 'Tests should be run' — passive voice obscures actor
+               Line 41: 'Refactor if appropriate' — vague condition
+
+    code-review                              1 warning, 1 info
+      WARNING  negative-only: Line 22: 'Never use SELECT *' has no positive alternative
+      INFO     attention-zone: Line 112: 'MUST validate input' in low-attention zone (segment 6/10)
+
+  CLAUDE.md (1)
+  ────────────────────────────────────────────────────────
+    CLAUDE.md                                1 warning, 1 info
+      WARNING  cross-component-conflict: CLAUDE.md says 'use spaces' but skill 'python-dev' says 'use tabs'
+      INFO     wall-of-text: '## Development' is ~720 tokens with no sub-headings
+```
+
+## Target component types
+
+Most rules target all text-bearing components (skills, commands, CLAUDE.md, agents). Exceptions:
+- `quality/tautological` skips CLAUDE.md (already covered by `claude-md/generic-advice`)
+- `quality/hook-candidate` targets CLAUDE.md and skills (commands and agents rarely contain hook-candidate instructions)
+- `quality/attention-zone` only fires on components with 80+ lines
+- `quality/cross-component-conflict` runs across all components via scan_state
+
+## Design principles
+
+1. **No false positives over missed findings.** Every rule has explicit false-positive mitigations. A rule that fires incorrectly on real-world setups erodes trust in the entire tool. It's better to miss a real issue than to flag legitimate content.
+
+2. **Context-aware analysis.** Rules don't just match patterns in isolation. They consider whether a line is in a code block, under a security heading, inside an examples section, or describing system behavior vs giving an instruction.
+
+3. **Cross-component awareness.** Several rules use `context.scan_state` to share data across the scan. `cross-component-conflict` compares fingerprints across all components. `hook-candidate` checks whether a matching hook already exists. This is infrastructure that per-file linters cannot provide.
+
+4. **Graduated severity.** Each rule's findings have appropriate severity based on impact. "Your critical instruction is in the middle of the file" is INFO (a suggestion). "Two components give contradictory instructions" is WARNING (will cause inconsistent behavior). Rules don't cry wolf.
+
+5. **Dogfood first.** Before shipping, every rule must produce zero false positives when run on this project's own setup and on 5+ real-world setups. Any false positive discovered during dogfooding must be addressed with a filter, not suppressed.
+
+## Open questions
+
+- Should `quality/tautological` share its pattern list with `claude-md/generic-advice` via `_patterns.py`, or keep separate lists? Sharing reduces maintenance but may need different patterns for skills (which are domain-scoped) vs CLAUDE.md (which is global).
+- What is the right threshold for `quality/wall-of-text`? 400 tokens is a starting point. May need calibration against real-world setups. Should it be configurable via rule options (e.g., `["warning", 600]`)?
+- For `quality/cross-component-conflict`: how to handle scope-aware conflict detection? Two skills that never activate together can safely contradict. Detecting scope overlap requires understanding skill trigger descriptions, which is fuzzy.
+- Should `quality/attention-zone` account for retrieval-augmented setups where the model's context is dynamically composed? In those setups, "position in file" is less meaningful than "position in assembled context."
+- How should these rules interact with the LLM review? Should the rubric prompt reference quality rules as categories for the LLM to check more deeply? (e.g., "The lint found 3 hedging instances; evaluate whether the surrounding context makes them acceptable.")
+
+## Success criteria
+
+- Phase 1 rules ship with tests and zero false positives when dogfooded on the project's own setup.
+- Rules add measurable value: running on 5+ real-world setups, each rule fires at least once on genuinely improvable content.
+- No performance regression: all rules complete within the existing lint budget (they're regex/heuristic, not LLM calls).
+- `quality/cross-component-conflict` detects at least one real contradiction in test setups assembled from multiple sources.
+- Rule count in README updates from 43 to 51.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "setup-eval"
-version = "3.6.2"
+version = "3.7.0"
 description = "Evaluate and compare AI agent setups through experiments, inspections, and rubric scoring."
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/harness_eval_lab/config/presets.py
+++ b/src/harness_eval_lab/config/presets.py
@@ -37,6 +37,12 @@ RECOMMENDED: dict[str, str] = {
     "agent/reverse-shell": "error",
     "agent/obfuscation": "error",
     "agent/data-exfiltration": "error",
+    # Quality rules
+    "quality/imprecise-instruction": "warning",
+    "quality/redundant-guidance": "warning",
+    "quality/unfinished-content": "warning",
+    "quality/example-gap": "info",
+    "quality/stale-references": "warning",
 }
 
 STRICT: dict[str, str] = {
@@ -53,6 +59,12 @@ STRICT: dict[str, str] = {
     "security/taint-flow": "error",
     "security/mcp-least-privilege": "error",
     "security/mcp-tool-poisoning": "error",
+    # Quality rules
+    "quality/imprecise-instruction": "error",
+    "quality/redundant-guidance": "error",
+    "quality/unfinished-content": "error",
+    "quality/example-gap": "warning",
+    "quality/stale-references": "error",
 }
 
 SECURITY: dict[str, str] = {
@@ -92,6 +104,12 @@ SECURITY: dict[str, str] = {
     "agent/reverse-shell": "error",
     "agent/obfuscation": "error",
     "agent/data-exfiltration": "error",
+    # Quality rules
+    "quality/imprecise-instruction": "off",
+    "quality/redundant-guidance": "off",
+    "quality/unfinished-content": "off",
+    "quality/example-gap": "off",
+    "quality/stale-references": "off",
 }
 
 PRE_WORKFLOW: dict[str, str] = {
@@ -127,6 +145,12 @@ PRE_WORKFLOW: dict[str, str] = {
     "agent/reverse-shell": "error",
     "agent/obfuscation": "error",
     "agent/data-exfiltration": "error",
+    # Quality rules
+    "quality/imprecise-instruction": "off",
+    "quality/redundant-guidance": "off",
+    "quality/unfinished-content": "off",
+    "quality/example-gap": "off",
+    "quality/stale-references": "off",
 }
 
 PRESETS: dict[str, dict[str, str]] = {

--- a/src/harness_eval_lab/inspection/rules/__init__.py
+++ b/src/harness_eval_lab/inspection/rules/__init__.py
@@ -75,6 +75,11 @@ def register_all_rules() -> None:
 
     # Hooks rules
     from harness_eval_lab.inspection.rules.hooks.valid_structure import HooksValidStructure
+    from harness_eval_lab.inspection.rules.quality.example_gap import ExampleGap
+    from harness_eval_lab.inspection.rules.quality.imprecise_instruction import ImpreciseInstruction
+    from harness_eval_lab.inspection.rules.quality.redundant_guidance import RedundantGuidance
+    from harness_eval_lab.inspection.rules.quality.stale_references import StaleReferences
+    from harness_eval_lab.inspection.rules.quality.unfinished_content import UnfinishedContent
     from harness_eval_lab.inspection.rules.security.ast_behavioral import AstBehavioral
     from harness_eval_lab.inspection.rules.security.cve_lookup import CveLookup
     from harness_eval_lab.inspection.rules.security.data_exfiltration import DataExfiltration
@@ -136,5 +141,10 @@ def register_all_rules() -> None:
         McpToolPoisoning,
         YaraScan,
         CveLookup,
+        ImpreciseInstruction,
+        RedundantGuidance,
+        UnfinishedContent,
+        ExampleGap,
+        StaleReferences,
     ]:
         register_rule(rule_cls())

--- a/src/harness_eval_lab/inspection/rules/quality/_patterns.py
+++ b/src/harness_eval_lab/inspection/rules/quality/_patterns.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import re
+
+TAUTOLOGICAL_PATTERNS: list[tuple[str, re.Pattern[str]]] = [
+    ("write clean code", re.compile(r"write\s+clean[\s,]+readable\s+code", re.I)),
+    ("be helpful", re.compile(r"be\s+helpful\s+and\s+thorough", re.I)),
+    ("follow best practices", re.compile(r"follow\s+(the\s+)?best\s+practices", re.I)),
+    ("think step by step", re.compile(r"think\s+step\s+by\s+step", re.I)),
+    ("consider edge cases", re.compile(r"consider\s+(all\s+)?edge\s+cases", re.I)),
+    (
+        "handle errors properly",
+        re.compile(r"handle\s+errors\s+(?:properly|correctly|gracefully)", re.I),
+    ),
+    ("use proper formatting", re.compile(r"use\s+proper\s+formatting", re.I)),
+    ("write maintainable code", re.compile(r"write\s+maintainable\s+code", re.I)),
+    ("be concise", re.compile(r"be\s+concise\s+and\s+clear", re.I)),
+    ("ensure code quality", re.compile(r"ensure\s+(?:code\s+)?quality", re.I)),
+    (
+        "write well-documented code",
+        re.compile(r"write\s+well[- ]documented\s+code", re.I),
+    ),
+    ("be thorough", re.compile(r"be\s+thorough\s+(?:in|and|with)", re.I)),
+    ("validate user input", re.compile(r"(?:always\s+)?validate\s+(?:all\s+)?user\s+input", re.I)),
+    (
+        "keep functions small",
+        re.compile(r"keep\s+(?:functions|methods)\s+(?:small|short|focused)", re.I),
+    ),
+    ("separate concerns", re.compile(r"separate\s+(?:your\s+)?concerns", re.I)),
+    (
+        "use meaningful names",
+        re.compile(
+            r"use\s+(?:meaningful|descriptive|clear)\s+(?:variable\s+)?names",
+            re.I,
+        ),
+    ),
+    ("avoid magic numbers", re.compile(r"avoid\s+(?:using\s+)?magic\s+numbers", re.I)),
+    ("write unit tests", re.compile(r"(?:always\s+)?write\s+(?:unit\s+)?tests", re.I)),
+    ("document your code", re.compile(r"document\s+(?:your\s+)?(?:code|changes)", re.I)),
+    ("review your changes", re.compile(r"review\s+(?:your\s+)?changes", re.I)),
+    (
+        "make sure code compiles",
+        re.compile(r"make\s+sure\s+(?:your\s+)?code\s+(?:compiles|builds)", re.I),
+    ),
+    ("DRY principle", re.compile(r"follow\s+(?:the\s+)?DRY\s+principle", re.I)),
+    (
+        "use version control",
+        re.compile(r"(?:always\s+)?use\s+(?:proper\s+)?version\s+control", re.I),
+    ),
+    (
+        "keep code organized",
+        re.compile(r"keep\s+(?:your\s+)?code\s+(?:organized|structured|tidy)", re.I),
+    ),
+]
+
+_SPECIFICITY_MARKERS = re.compile(
+    r"(?:"
+    r"`[^`]+`"  # backtick-quoted terms
+    r"|\.(?:py|ts|js|tsx|jsx|rs|go|rb|java|yaml|yml|toml|json|md)\b"  # file extensions
+    r"|(?:^|[\s(])\.?/"  # path-like strings
+    r")",
+    re.M,
+)
+
+
+def has_project_specificity(line: str) -> bool:
+    return bool(_SPECIFICITY_MARKERS.search(line))

--- a/src/harness_eval_lab/inspection/rules/quality/example_gap.py
+++ b/src/harness_eval_lab/inspection/rules/quality/example_gap.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import re
+
+from harness_eval_lab.inspection.types import (
+    Location,
+    ReportDescriptor,
+    RuleCategory,
+    RuleContext,
+    RuleMeta,
+    Severity,
+)
+
+_INSTRUCTION_SIGNAL = re.compile(
+    r"(?:"
+    r"\b(?:always|never|must|should|do\s+not|don'?t|ensure|make\s+sure)\b"
+    r"|\b(?:use|prefer|avoid|follow|run|execute|configure|set|add)\s+\w+"
+    r")",
+    re.I,
+)
+
+_MIN_INSTRUCTION_LINES = 5
+_MIN_BODY_TOKENS = 50
+
+
+class ExampleGap:
+    meta = RuleMeta(
+        id="quality/example-gap",
+        default_severity=Severity.INFO,
+        fixable=False,
+        description="Skills with instructions but no examples are less effective",
+        category=RuleCategory.CONTENT,
+        messages={
+            "no_examples": (
+                "Skill has {{instruction_count}} instruction lines but no code examples. "
+                "Adding a code block with a concrete example improves compliance."
+            ),
+        },
+    )
+
+    def create(self, context: RuleContext) -> None:
+        skill = context.skill
+        if not skill.body:
+            return
+
+        if skill.tokens < _MIN_BODY_TOKENS:
+            return
+
+        lines = skill.body.split("\n")
+        has_code_block = False
+        instruction_count = 0
+        in_code_fence = False
+
+        for line in lines:
+            stripped = line.strip()
+
+            if stripped.startswith("```"):
+                in_code_fence = not in_code_fence
+                has_code_block = True
+                continue
+
+            if in_code_fence:
+                continue
+
+            if _INSTRUCTION_SIGNAL.search(stripped):
+                instruction_count += 1
+
+        if has_code_block:
+            return
+
+        if instruction_count < _MIN_INSTRUCTION_LINES:
+            return
+
+        context.report(
+            ReportDescriptor(
+                message_id="no_examples",
+                data={"instruction_count": str(instruction_count)},
+                location=Location(file=skill.skill_md_path, start_line=1),
+            )
+        )

--- a/src/harness_eval_lab/inspection/rules/quality/imprecise_instruction.py
+++ b/src/harness_eval_lab/inspection/rules/quality/imprecise_instruction.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import re
+
+from harness_eval_lab.inspection.types import (
+    Location,
+    ReportDescriptor,
+    RuleCategory,
+    RuleContext,
+    RuleMeta,
+    Severity,
+)
+
+_HEDGING: list[tuple[str, re.Pattern[str]]] = [
+    ("try to", re.compile(r"\btry\s+to\s+\w+", re.I)),
+    ("if possible", re.compile(r"\bif\s+(?:at\s+all\s+)?possible\b", re.I)),
+    ("you might want to", re.compile(r"\byou\s+might\s+(?:want|wish)\s+to\b", re.I)),
+    ("perhaps consider", re.compile(r"\bperhaps\s+(?:consider|you)\b", re.I)),
+    ("ideally", re.compile(r"\bideally\s+(?:you\s+)?should\b", re.I)),
+    ("it would be nice", re.compile(r"\bit\s+would\s+be\s+(?:nice|good)\s+(?:to|if)\b", re.I)),
+    ("consider using", re.compile(r"\bconsider\s+(?:using|adding|implementing)\b", re.I)),
+]
+
+_PAST_PARTICIPLES = (
+    r"(?:run|checked|tested|validated|formatted|built|deployed|used|added|removed"
+    r"|created|updated|linted|installed|configured|generated|executed|compiled"
+    r"|reviewed|analyzed|scanned|parsed|processed|evaluated|verified|merged"
+    r"|committed|pushed|released|published)"
+)
+
+_PASSIVE: list[tuple[str, re.Pattern[str]]] = [
+    (
+        "should be",
+        re.compile(rf"\bshould\s+be\s+{_PAST_PARTICIPLES}\b", re.I),
+    ),
+    (
+        "needs to be",
+        re.compile(rf"\bneeds?\s+to\s+be\s+{_PAST_PARTICIPLES}\b", re.I),
+    ),
+    (
+        "is expected to be",
+        re.compile(rf"\bis\s+expected\s+to\s+be\s+{_PAST_PARTICIPLES}\b", re.I),
+    ),
+    (
+        "must be",
+        re.compile(rf"\bmust\s+be\s+{_PAST_PARTICIPLES}\b", re.I),
+    ),
+]
+
+_CONDITIONAL_AMBIGUITY: list[tuple[str, re.Pattern[str]]] = [
+    ("if needed", re.compile(r"\bif\s+needed\b", re.I)),
+    ("if appropriate", re.compile(r"\bif\s+appropriate\b", re.I)),
+    ("when relevant", re.compile(r"\bwhen\s+relevant\b", re.I)),
+    ("as necessary", re.compile(r"\bas\s+necessary\b", re.I)),
+    ("if applicable", re.compile(r"\bif\s+applicable\b", re.I)),
+    ("where suitable", re.compile(r"\bwhere\s+suitable\b", re.I)),
+]
+
+_ALL_PATTERNS: list[tuple[str, str, re.Pattern[str]]] = (
+    [("hedging", label, pat) for label, pat in _HEDGING]
+    + [("passive", label, pat) for label, pat in _PASSIVE]
+    + [("vague condition", label, pat) for label, pat in _CONDITIONAL_AMBIGUITY]
+)
+
+_CATEGORY_ADVICE = {
+    "hedging": "State directly for reliable compliance",
+    "passive": "Use active voice with the agent as subject",
+    "vague condition": "Specify a testable condition",
+}
+
+
+class ImpreciseInstruction:
+    meta = RuleMeta(
+        id="quality/imprecise-instruction",
+        default_severity=Severity.WARNING,
+        fixable=False,
+        description="Instructions should use direct, unambiguous language",
+        category=RuleCategory.CONTENT,
+        messages={
+            "imprecise": ("Line {{line}}: '{{match}}' — {{category}}. {{advice}}"),
+        },
+    )
+
+    def create(self, context: RuleContext) -> None:
+        skill = context.skill
+        if not skill.body:
+            return
+
+        lines = skill.body.split("\n")
+        in_code_fence = False
+
+        for i, line in enumerate(lines):
+            stripped = line.strip()
+
+            if stripped.startswith("```"):
+                in_code_fence = not in_code_fence
+                continue
+
+            if in_code_fence:
+                continue
+
+            if stripped.startswith(">"):
+                continue
+
+            for category, label, pattern in _ALL_PATTERNS:
+                if pattern.search(line):
+                    context.report(
+                        ReportDescriptor(
+                            message_id="imprecise",
+                            data={
+                                "line": str(skill.body_start_line + i),
+                                "match": label,
+                                "category": category,
+                                "advice": _CATEGORY_ADVICE[category],
+                            },
+                            location=Location(
+                                file=skill.skill_md_path,
+                                start_line=skill.body_start_line + i,
+                            ),
+                        )
+                    )
+                    break

--- a/src/harness_eval_lab/inspection/rules/quality/redundant_guidance.py
+++ b/src/harness_eval_lab/inspection/rules/quality/redundant_guidance.py
@@ -1,0 +1,216 @@
+from __future__ import annotations
+
+import os
+import re
+
+from harness_eval_lab.inspection.rules.quality._patterns import (
+    TAUTOLOGICAL_PATTERNS,
+    has_project_specificity,
+)
+from harness_eval_lab.inspection.types import (
+    Location,
+    ReportDescriptor,
+    RuleCategory,
+    RuleContext,
+    RuleMeta,
+    Severity,
+)
+
+_CONFIG_TOOL_PATTERNS: list[tuple[str, str, re.Pattern[str]]] = [
+    (
+        ".editorconfig",
+        "indentation style",
+        re.compile(
+            r"(?:use|prefer|set)\s+(?:\d[- ]space|tab)\s+indent",
+            re.I,
+        ),
+    ),
+    (
+        ".editorconfig",
+        "trailing whitespace",
+        re.compile(r"(?:remove|trim|strip)\s+trailing\s+(?:whitespace|spaces)", re.I),
+    ),
+    (
+        ".editorconfig",
+        "final newline",
+        re.compile(r"(?:ensure|add|include)\s+(?:a\s+)?final\s+newline", re.I),
+    ),
+    (
+        ".prettierrc",
+        "code formatting",
+        re.compile(
+            r"(?:use|prefer)\s+(?:single|double)\s+quotes",
+            re.I,
+        ),
+    ),
+    (
+        ".prettierrc",
+        "semicolons",
+        re.compile(r"(?:always\s+)?(?:use|add|include|omit)\s+semicolons", re.I),
+    ),
+    (
+        ".prettierrc",
+        "trailing commas",
+        re.compile(r"(?:use|add|include)\s+trailing\s+commas", re.I),
+    ),
+    (
+        ".eslintrc",
+        "lint rules",
+        re.compile(
+            r"(?:no|avoid|don'?t\s+use)\s+(?:var\b|console\.log|unused\s+variables)",
+            re.I,
+        ),
+    ),
+    (
+        "tsconfig.json",
+        "strict mode",
+        re.compile(r"(?:enable|use)\s+(?:typescript\s+)?strict\s+mode", re.I),
+    ),
+    (
+        "pyproject.toml",
+        "line length",
+        re.compile(r"(?:keep|limit|set)\s+(?:line\s+)?length\s+(?:to|at|under)\s+\d+", re.I),
+    ),
+]
+
+_CONFIG_FILES = {
+    ".editorconfig": [".editorconfig"],
+    ".prettierrc": [
+        ".prettierrc",
+        ".prettierrc.json",
+        ".prettierrc.yml",
+        ".prettierrc.yaml",
+        ".prettierrc.js",
+        "prettier.config.js",
+        "prettier.config.cjs",
+    ],
+    ".eslintrc": [
+        ".eslintrc",
+        ".eslintrc.json",
+        ".eslintrc.yml",
+        ".eslintrc.js",
+        "eslint.config.js",
+        "eslint.config.mjs",
+        "eslint.config.ts",
+    ],
+    "tsconfig.json": ["tsconfig.json"],
+    "pyproject.toml": ["pyproject.toml"],
+}
+
+
+def _find_project_root(skill_path: str) -> str | None:
+    path = os.path.dirname(os.path.abspath(skill_path))
+    for _ in range(10):
+        if os.path.isdir(os.path.join(path, ".git")):
+            return path
+        parent = os.path.dirname(path)
+        if parent == path:
+            break
+        path = parent
+    return None
+
+
+def _config_exists(project_root: str, config_key: str) -> bool:
+    candidates = _CONFIG_FILES.get(config_key, [])
+    return any(os.path.isfile(os.path.join(project_root, c)) for c in candidates)
+
+
+class RedundantGuidance:
+    meta = RuleMeta(
+        id="quality/redundant-guidance",
+        default_severity=Severity.WARNING,
+        fixable=False,
+        description=(
+            "Detect instructions that are redundant with model defaults or project tooling"
+        ),
+        category=RuleCategory.CONTENT,
+        messages={
+            "default_behavior": (
+                "Line {{line}}: '{{label}}' — the model does this by default. "
+                "Either remove or add project-specific detail."
+            ),
+            "tooling_redundant": (
+                "Line {{line}}: '{{label}}' — already enforced by {{config}} "
+                "in this project. Remove to avoid contradictions."
+            ),
+        },
+    )
+
+    def create(self, context: RuleContext) -> None:
+        skill = context.skill
+        if not skill.body:
+            return
+
+        project_root = _find_project_root(skill.skill_md_path)
+
+        present_configs: set[str] = set()
+        if project_root:
+            for config_key in _CONFIG_FILES:
+                if _config_exists(project_root, config_key):
+                    present_configs.add(config_key)
+
+        lines = skill.body.split("\n")
+        in_code_fence = False
+
+        for i, line in enumerate(lines):
+            stripped = line.strip()
+
+            if stripped.startswith("```"):
+                in_code_fence = not in_code_fence
+                continue
+
+            if in_code_fence:
+                continue
+
+            if self._check_tooling(context, skill, line, i, present_configs):
+                continue
+
+            if has_project_specificity(line):
+                continue
+
+            for label, pattern in TAUTOLOGICAL_PATTERNS:
+                if pattern.search(line):
+                    context.report(
+                        ReportDescriptor(
+                            message_id="default_behavior",
+                            data={
+                                "label": label,
+                                "line": str(skill.body_start_line + i),
+                            },
+                            location=Location(
+                                file=skill.skill_md_path,
+                                start_line=skill.body_start_line + i,
+                            ),
+                        )
+                    )
+                    break
+
+    def _check_tooling(
+        self,
+        context: RuleContext,
+        skill,  # noqa: ANN001
+        line: str,
+        line_idx: int,
+        present_configs: set[str],
+    ) -> bool:
+        if not present_configs:
+            return False
+
+        for config_key, label, pattern in _CONFIG_TOOL_PATTERNS:
+            if config_key in present_configs and pattern.search(line):
+                context.report(
+                    ReportDescriptor(
+                        message_id="tooling_redundant",
+                        data={
+                            "label": label,
+                            "config": config_key,
+                            "line": str(skill.body_start_line + line_idx),
+                        },
+                        location=Location(
+                            file=skill.skill_md_path,
+                            start_line=skill.body_start_line + line_idx,
+                        ),
+                    )
+                )
+                return True
+        return False

--- a/src/harness_eval_lab/inspection/rules/quality/stale_references.py
+++ b/src/harness_eval_lab/inspection/rules/quality/stale_references.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+import re
+
+from harness_eval_lab.inspection.types import (
+    Location,
+    ReportDescriptor,
+    RuleCategory,
+    RuleContext,
+    RuleMeta,
+    Severity,
+)
+
+_STALE_PATTERNS: list[tuple[str, str, re.Pattern[str]]] = [
+    (
+        "text-davinci-003",
+        "Use claude-sonnet-4-6 or gpt-4o",
+        re.compile(r"\btext-davinci-\d+\b", re.I),
+    ),
+    (
+        "gpt-3.5-turbo",
+        "Use gpt-4o-mini or claude-haiku-4-5",
+        re.compile(r"\bgpt-3\.5-turbo\b", re.I),
+    ),
+    (
+        "code-davinci",
+        "Use claude-sonnet-4-6 or gpt-4o",
+        re.compile(r"\bcode-davinci-\d+\b", re.I),
+    ),
+    (
+        "Codex API",
+        "Use the Chat Completions API",
+        re.compile(r"\bcodex\s+api\b", re.I),
+    ),
+    (
+        "OpenAI Completions (legacy)",
+        "Use the Chat Completions endpoint",
+        re.compile(r"\b/v1/completions\b"),
+    ),
+    (
+        "Claude v1",
+        "Use claude-sonnet-4-6 or claude-haiku-4-5",
+        re.compile(r"\bclaude-(?:v1|1(?:\.\d)?|instant-v1)\b", re.I),
+    ),
+    (
+        "Claude 2",
+        "Use claude-sonnet-4-6 or claude-haiku-4-5",
+        re.compile(r"\bclaude-2(?:\.\d)?\b", re.I),
+    ),
+    (
+        "PaLM API",
+        "Use the Gemini API",
+        re.compile(r"\bpalm[\s-](?:api|2)\b", re.I),
+    ),
+    (
+        "Node 14/16",
+        "Use Node 18+ (LTS)",
+        re.compile(r"\bnode\s+(?:14|16)\b", re.I),
+    ),
+    (
+        "Python 3.7/3.8",
+        "Use Python 3.11+",
+        re.compile(r"\bpython\s+3\.(?:7|8)\b", re.I),
+    ),
+    (
+        "create-react-app",
+        "Use Vite or Next.js",
+        re.compile(r"\bcreate-react-app\b", re.I),
+    ),
+    (
+        "tslint",
+        "Use eslint with @typescript-eslint",
+        re.compile(r"\btslint\b", re.I),
+    ),
+    (
+        "moment.js",
+        "Use date-fns, dayjs, or Temporal",
+        re.compile(r"\bmoment(?:\.js)?\b(?!\s*[\(.])", re.I),
+    ),
+    (
+        "request (npm package)",
+        "Use fetch, undici, or axios",
+        re.compile(r"\brequire\s*\(\s*['\"]request['\"]\s*\)", re.I),
+    ),
+]
+
+
+class StaleReferences:
+    meta = RuleMeta(
+        id="quality/stale-references",
+        default_severity=Severity.WARNING,
+        fixable=False,
+        description="Detect deprecated models, sunset APIs, and outdated tool references",
+        category=RuleCategory.CONTENT,
+        messages={
+            "stale": ("Line {{line}}: '{{label}}' is outdated. {{replacement}}"),
+        },
+    )
+
+    def create(self, context: RuleContext) -> None:
+        skill = context.skill
+        if not skill.body:
+            return
+
+        lines = skill.body.split("\n")
+        in_code_fence = False
+
+        for i, line in enumerate(lines):
+            stripped = line.strip()
+
+            if stripped.startswith("```"):
+                in_code_fence = not in_code_fence
+                continue
+
+            if in_code_fence:
+                continue
+
+            for label, replacement, pattern in _STALE_PATTERNS:
+                if pattern.search(line):
+                    context.report(
+                        ReportDescriptor(
+                            message_id="stale",
+                            data={
+                                "line": str(skill.body_start_line + i),
+                                "label": label,
+                                "replacement": replacement,
+                            },
+                            location=Location(
+                                file=skill.skill_md_path,
+                                start_line=skill.body_start_line + i,
+                            ),
+                        )
+                    )
+                    break

--- a/src/harness_eval_lab/inspection/rules/quality/unfinished_content.py
+++ b/src/harness_eval_lab/inspection/rules/quality/unfinished_content.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+import re
+
+from harness_eval_lab.inspection.types import (
+    Location,
+    ReportDescriptor,
+    RuleCategory,
+    RuleContext,
+    RuleMeta,
+    Severity,
+)
+
+_PLACEHOLDER_PATTERNS: list[tuple[str, re.Pattern[str]]] = [
+    (
+        "insert placeholder",
+        re.compile(
+            r"\[(?:INSERT|FILL\s+IN|CHANGE\s+THIS|UPDATE\s+THIS|REPLACE)\s+[^\]]+\]",
+            re.I,
+        ),
+    ),
+    ("your-placeholder", re.compile(r"\[YOUR\s+[^\]]+\]", re.I)),
+    ("angle-bracket placeholder", re.compile(r"<your[-_][a-z][-_a-z]*[-_]here>", re.I)),
+    ("PLACEHOLDER marker", re.compile(r"\[PLACEHOLDER\]", re.I)),
+]
+
+_PLACEHOLDER_WORDS = (
+    r"(?:YOUR|INSERT|PROJECT|DESCRIPTION|API|KEY|TOKEN|URL|PATH|NAME|TEAM|ORG|COMPANY|REPO)"
+)
+
+_UNFINISHED_MARKERS: list[tuple[str, re.Pattern[str]]] = [
+    ("TODO marker", re.compile(r"\bTODO\s*:", re.I)),
+    ("FIXME marker", re.compile(r"\bFIXME\s*:", re.I)),
+    ("XXX marker", re.compile(r"\bXXX\s*:", re.I)),
+    (
+        "bracket ALL-CAPS placeholder",
+        re.compile(rf"\[{_PLACEHOLDER_WORDS}(?:_[A-Z]+)*\]"),
+    ),
+]
+
+_DEFERRED_PATTERNS: list[tuple[str, re.Pattern[str]]] = [
+    ("TBD", re.compile(r"\bTBD\b")),
+    ("to be determined", re.compile(r"\bto\s+be\s+(?:determined|decided|defined)\b", re.I)),
+    ("coming soon", re.compile(r"\bcoming\s+soon\b", re.I)),
+    ("work in progress", re.compile(r"\bwork\s+in\s+progress\b", re.I)),
+    ("not yet implemented", re.compile(r"\bnot\s+yet\s+(?:implemented|done|complete)\b", re.I)),
+]
+
+_HEADING_RE = re.compile(r"^#{1,6}\s+\S")
+
+
+class UnfinishedContent:
+    meta = RuleMeta(
+        id="quality/unfinished-content",
+        default_severity=Severity.WARNING,
+        fixable=False,
+        description="Detect placeholders, deferred content, and empty sections",
+        category=RuleCategory.CONTENT,
+        messages={
+            "placeholder": "Line {{line}}: '{{match}}' looks like unfilled template text",
+            "unfinished": "Line {{line}}: '{{match}}' — unfinished section",
+            "deferred": "Line {{line}}: '{{match}}' — deferred content wastes tokens",
+            "empty_section": (
+                "Line {{line}}: section '{{heading}}' has no content. "
+                "Add content or remove the heading."
+            ),
+        },
+    )
+
+    def create(self, context: RuleContext) -> None:
+        skill = context.skill
+        if not skill.raw_content:
+            return
+
+        lines = skill.raw_content.split("\n")
+        in_code_fence = False
+
+        prev_heading: tuple[int, str] | None = None
+        prev_heading_had_content = False
+
+        for i, line in enumerate(lines):
+            stripped = line.strip()
+
+            if stripped.startswith("```"):
+                in_code_fence = not in_code_fence
+                if not in_code_fence and prev_heading is not None:
+                    prev_heading_had_content = True
+                continue
+
+            if in_code_fence:
+                continue
+
+            is_heading = bool(_HEADING_RE.match(stripped))
+
+            if is_heading:
+                if prev_heading is not None and not prev_heading_had_content:
+                    h_line, h_text = prev_heading
+                    context.report(
+                        ReportDescriptor(
+                            message_id="empty_section",
+                            data={"line": str(h_line + 1), "heading": h_text},
+                            location=Location(
+                                file=skill.skill_md_path,
+                                start_line=h_line + 1,
+                            ),
+                        )
+                    )
+                prev_heading = (i, stripped.lstrip("#").strip())
+                prev_heading_had_content = False
+                continue
+
+            if stripped and prev_heading is not None:
+                prev_heading_had_content = True
+
+            self._check_line(context, skill, line, stripped, i)
+
+        if prev_heading is not None and not prev_heading_had_content:
+            h_line, h_text = prev_heading
+            context.report(
+                ReportDescriptor(
+                    message_id="empty_section",
+                    data={"line": str(h_line + 1), "heading": h_text},
+                    location=Location(
+                        file=skill.skill_md_path,
+                        start_line=h_line + 1,
+                    ),
+                )
+            )
+
+    def _check_line(
+        self,
+        context: RuleContext,
+        skill,  # noqa: ANN001
+        line: str,
+        stripped: str,
+        line_idx: int,
+    ) -> None:
+        if not stripped:
+            return
+
+        for _label, pattern in _PLACEHOLDER_PATTERNS:
+            m = pattern.search(line)
+            if m:
+                context.report(
+                    ReportDescriptor(
+                        message_id="placeholder",
+                        data={"line": str(line_idx + 1), "match": m.group(0)},
+                        location=Location(file=skill.skill_md_path, start_line=line_idx + 1),
+                    )
+                )
+                return
+
+        for label, pattern in _UNFINISHED_MARKERS:
+            m = pattern.search(line)
+            if m:
+                msg_id = "unfinished" if "marker" in label else "placeholder"
+                context.report(
+                    ReportDescriptor(
+                        message_id=msg_id,
+                        data={"line": str(line_idx + 1), "match": m.group(0)},
+                        location=Location(file=skill.skill_md_path, start_line=line_idx + 1),
+                    )
+                )
+                return
+
+        for _label, pattern in _DEFERRED_PATTERNS:
+            m = pattern.search(line)
+            if m:
+                context.report(
+                    ReportDescriptor(
+                        message_id="deferred",
+                        data={"line": str(line_idx + 1), "match": m.group(0)},
+                        location=Location(file=skill.skill_md_path, start_line=line_idx + 1),
+                    )
+                )
+                return

--- a/tests/test_quality_rules.py
+++ b/tests/test_quality_rules.py
@@ -1,0 +1,334 @@
+"""Tests for quality/ lint rules."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from harness_eval_lab.inspection.engine import lint
+
+IMPRECISE = "quality/imprecise-instruction"
+REDUNDANT = "quality/redundant-guidance"
+UNFINISHED = "quality/unfinished-content"
+EXAMPLE_GAP = "quality/example-gap"
+STALE = "quality/stale-references"
+
+
+def _make_skill(tmp_path: Path, name: str, body: str) -> str:
+    skill_dir = tmp_path / name
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text(
+        f"---\nname: {name}\ndescription: Test skill\n---\n\n{body}"
+    )
+    return str(skill_dir)
+
+
+def _rule_ids(path: str) -> set[str]:
+    return {d.rule_id for d in lint(path).diagnostics}
+
+
+def _findings_for(path: str, rule_id: str) -> list:
+    return [d for d in lint(path).diagnostics if d.rule_id == rule_id]
+
+
+# --- ImpreciseInstruction ---
+
+
+class TestImpreciseInstruction:
+    def test_hedging_try_to(self, tmp_path: Path) -> None:
+        path = _make_skill(tmp_path, "s1", "Try to use TypeScript for all new files.")
+        assert IMPRECISE in _rule_ids(path)
+
+    def test_hedging_if_possible(self, tmp_path: Path) -> None:
+        path = _make_skill(tmp_path, "s2", "Use Python 3.12 if possible.")
+        assert IMPRECISE in _rule_ids(path)
+
+    def test_hedging_consider_using(self, tmp_path: Path) -> None:
+        path = _make_skill(tmp_path, "s3", "Consider using dataclasses for DTOs.")
+        assert IMPRECISE in _rule_ids(path)
+
+    def test_passive_should_be_run(self, tmp_path: Path) -> None:
+        path = _make_skill(tmp_path, "s4", "Tests should be run before merging.")
+        assert IMPRECISE in _rule_ids(path)
+
+    def test_passive_needs_to_be_validated(self, tmp_path: Path) -> None:
+        path = _make_skill(tmp_path, "s5", "Input needs to be validated first.")
+        assert IMPRECISE in _rule_ids(path)
+
+    def test_conditional_if_appropriate(self, tmp_path: Path) -> None:
+        path = _make_skill(tmp_path, "s6", "Refactor the module if appropriate.")
+        msgs = [d.message for d in _findings_for(path, IMPRECISE)]
+        assert any("vague condition" in m for m in msgs)
+
+    def test_no_flag_in_code_block(self, tmp_path: Path) -> None:
+        body = "```python\n# Try to connect to the database\ndb.connect()\n```"
+        path = _make_skill(tmp_path, "s7", body)
+        assert len(_findings_for(path, IMPRECISE)) == 0
+
+    def test_no_flag_blockquote(self, tmp_path: Path) -> None:
+        path = _make_skill(tmp_path, "s8", "> Try to keep this in mind.")
+        assert len(_findings_for(path, IMPRECISE)) == 0
+
+    def test_no_flag_direct_instruction(self, tmp_path: Path) -> None:
+        path = _make_skill(tmp_path, "s9", "Use TypeScript for all new files.")
+        assert len(_findings_for(path, IMPRECISE)) == 0
+
+    def test_no_flag_descriptive_passive(self, tmp_path: Path) -> None:
+        path = _make_skill(tmp_path, "s10", "The database is hosted on AWS.")
+        assert len(_findings_for(path, IMPRECISE)) == 0
+
+    def test_passive_must_be_checked(self, tmp_path: Path) -> None:
+        path = _make_skill(tmp_path, "s11", "All endpoints must be tested before release.")
+        assert IMPRECISE in _rule_ids(path)
+
+
+# --- RedundantGuidance ---
+
+
+class TestRedundantGuidance:
+    def test_follow_best_practices(self, tmp_path: Path) -> None:
+        path = _make_skill(tmp_path, "r1", "Always follow best practices when coding.")
+        assert REDUNDANT in _rule_ids(path)
+
+    def test_write_clean_code(self, tmp_path: Path) -> None:
+        path = _make_skill(tmp_path, "r2", "Write clean, readable code.")
+        assert REDUNDANT in _rule_ids(path)
+
+    def test_handle_errors_properly(self, tmp_path: Path) -> None:
+        path = _make_skill(tmp_path, "r3", "Handle errors properly in all functions.")
+        assert REDUNDANT in _rule_ids(path)
+
+    def test_write_unit_tests(self, tmp_path: Path) -> None:
+        path = _make_skill(tmp_path, "r4", "Always write unit tests for new features.")
+        assert REDUNDANT in _rule_ids(path)
+
+    def test_avoid_magic_numbers(self, tmp_path: Path) -> None:
+        path = _make_skill(tmp_path, "r5", "Avoid magic numbers in your code.")
+        assert REDUNDANT in _rule_ids(path)
+
+    def test_no_flag_specific_instruction(self, tmp_path: Path) -> None:
+        path = _make_skill(
+            tmp_path,
+            "r6",
+            "Use `pytest` with fixtures in `tests/conftest.py`.",
+        )
+        assert len(_findings_for(path, REDUNDANT)) == 0
+
+    def test_no_flag_with_file_path(self, tmp_path: Path) -> None:
+        path = _make_skill(
+            tmp_path,
+            "r7",
+            "Write unit tests using patterns in ./tests/helpers.py",
+        )
+        assert len(_findings_for(path, REDUNDANT)) == 0
+
+    def test_no_flag_in_code_block(self, tmp_path: Path) -> None:
+        body = "```\nFollow best practices for error handling.\n```"
+        path = _make_skill(tmp_path, "r8", body)
+        assert len(_findings_for(path, REDUNDANT)) == 0
+
+    def test_no_flag_specific_with_extension(self, tmp_path: Path) -> None:
+        path = _make_skill(
+            tmp_path,
+            "r9",
+            "Validate user input in all .py files using pydantic.",
+        )
+        assert len(_findings_for(path, REDUNDANT)) == 0
+
+    def test_keep_functions_small(self, tmp_path: Path) -> None:
+        path = _make_skill(tmp_path, "r10", "Keep functions small and focused.")
+        assert REDUNDANT in _rule_ids(path)
+
+    def test_document_your_code(self, tmp_path: Path) -> None:
+        path = _make_skill(tmp_path, "r11", "Document your code thoroughly.")
+        assert REDUNDANT in _rule_ids(path)
+
+    def test_tooling_redundant_with_editorconfig(self, tmp_path: Path) -> None:
+        (tmp_path / ".git").mkdir()
+        (tmp_path / ".editorconfig").write_text("[*]\nindent_style = space\n")
+        skill_dir = tmp_path / "skills" / "my-skill"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: my-skill\ndescription: test\n---\n\nUse 2-space indentation for all files."
+        )
+        result = lint(str(skill_dir))
+        msgs = [d.message for d in result.diagnostics if d.rule_id == REDUNDANT]
+        assert any(".editorconfig" in m for m in msgs)
+
+    def test_no_tooling_flag_without_config(self, tmp_path: Path) -> None:
+        (tmp_path / ".git").mkdir()
+        skill_dir = tmp_path / "skills" / "my-skill"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: my-skill\ndescription: test\n---\n\nUse 2-space indentation for all files."
+        )
+        result = lint(str(skill_dir))
+        msgs = [d.message for d in result.diagnostics if d.rule_id == REDUNDANT]
+        assert not any(".editorconfig" in m for m in msgs)
+
+
+# --- UnfinishedContent ---
+
+
+class TestUnfinishedContent:
+    def test_insert_placeholder(self, tmp_path: Path) -> None:
+        path = _make_skill(tmp_path, "u1", "Project: [INSERT YOUR PROJECT NAME]")
+        assert UNFINISHED in _rule_ids(path)
+
+    def test_your_placeholder(self, tmp_path: Path) -> None:
+        path = _make_skill(tmp_path, "u2", "API key: [YOUR API KEY]")
+        assert UNFINISHED in _rule_ids(path)
+
+    def test_angle_bracket_placeholder(self, tmp_path: Path) -> None:
+        path = _make_skill(tmp_path, "u3", "Replace <your-name-here> with your name.")
+        assert UNFINISHED in _rule_ids(path)
+
+    def test_todo_marker(self, tmp_path: Path) -> None:
+        path = _make_skill(tmp_path, "u4", "TODO: add deployment instructions here.")
+        assert UNFINISHED in _rule_ids(path)
+
+    def test_fixme_marker(self, tmp_path: Path) -> None:
+        path = _make_skill(tmp_path, "u5", "FIXME: this section is incomplete.")
+        assert UNFINISHED in _rule_ids(path)
+
+    def test_bracket_allcaps_placeholder(self, tmp_path: Path) -> None:
+        path = _make_skill(tmp_path, "u6", "Set [YOUR_API_KEY] in the environment.")
+        assert UNFINISHED in _rule_ids(path)
+
+    def test_no_flag_in_code_block(self, tmp_path: Path) -> None:
+        body = "```yaml\n# TODO: configure this\nkey: value\n```"
+        path = _make_skill(tmp_path, "u7", body)
+        assert len(_findings_for(path, UNFINISHED)) == 0
+
+    def test_no_flag_rfc_reference(self, tmp_path: Path) -> None:
+        path = _make_skill(tmp_path, "u8", "Follow [RFC 2119] for keywords.")
+        assert len(_findings_for(path, UNFINISHED)) == 0
+
+    def test_no_flag_normal_brackets(self, tmp_path: Path) -> None:
+        path = _make_skill(tmp_path, "u9", "Use [Section 3.1] as a reference.")
+        assert len(_findings_for(path, UNFINISHED)) == 0
+
+    def test_no_flag_todo_without_colon(self, tmp_path: Path) -> None:
+        path = _make_skill(tmp_path, "u10", "We need to decide the todo list format.")
+        assert len(_findings_for(path, UNFINISHED)) == 0
+
+    def test_placeholder_marker(self, tmp_path: Path) -> None:
+        path = _make_skill(tmp_path, "u11", "Description: [PLACEHOLDER]")
+        assert UNFINISHED in _rule_ids(path)
+
+    def test_tbd_marker(self, tmp_path: Path) -> None:
+        path = _make_skill(tmp_path, "u12", "Deployment strategy: TBD")
+        assert UNFINISHED in _rule_ids(path)
+
+    def test_coming_soon(self, tmp_path: Path) -> None:
+        path = _make_skill(tmp_path, "u13", "This feature is coming soon.")
+        assert UNFINISHED in _rule_ids(path)
+
+    def test_not_yet_implemented(self, tmp_path: Path) -> None:
+        path = _make_skill(tmp_path, "u14", "Error handling is not yet implemented.")
+        assert UNFINISHED in _rule_ids(path)
+
+    def test_empty_section(self, tmp_path: Path) -> None:
+        body = "Some intro text.\n\n## Empty Section\n\n## Next Section\n\nContent here."
+        path = _make_skill(tmp_path, "u15", body)
+        msgs = [d.message for d in _findings_for(path, UNFINISHED)]
+        assert any("Empty Section" in m for m in msgs)
+
+    def test_no_flag_section_with_content(self, tmp_path: Path) -> None:
+        body = "## Filled Section\n\nThis has content.\n\n## Another\n\nAlso has content."
+        path = _make_skill(tmp_path, "u16", body)
+        empty_findings = [d for d in _findings_for(path, UNFINISHED) if "no content" in d.message]
+        assert len(empty_findings) == 0
+
+    def test_work_in_progress(self, tmp_path: Path) -> None:
+        path = _make_skill(tmp_path, "u17", "This section is a work in progress.")
+        assert UNFINISHED in _rule_ids(path)
+
+
+# --- ExampleGap ---
+
+
+class TestExampleGap:
+    def _long_instructions(self) -> str:
+        return "\n".join(
+            [
+                "Always use TypeScript strict mode.",
+                "Never commit directly to main.",
+                "Use conventional commits for all messages.",
+                "Run the linter before every push.",
+                "Ensure all tests pass before merging.",
+                "Follow the project naming conventions.",
+                "Use absolute imports throughout.",
+                "Avoid circular dependencies between modules.",
+                "Set environment variables via the .env file.",
+                "Do not hardcode API endpoints.",
+            ]
+        )
+
+    def test_no_examples_triggers(self, tmp_path: Path) -> None:
+        path = _make_skill(tmp_path, "e1", self._long_instructions())
+        assert EXAMPLE_GAP in _rule_ids(path)
+
+    def test_with_code_block_passes(self, tmp_path: Path) -> None:
+        body = self._long_instructions() + "\n\n```ts\nconst x = 1;\n```"
+        path = _make_skill(tmp_path, "e2", body)
+        assert len(_findings_for(path, EXAMPLE_GAP)) == 0
+
+    def test_short_skill_not_flagged(self, tmp_path: Path) -> None:
+        path = _make_skill(tmp_path, "e3", "Use TypeScript.")
+        assert len(_findings_for(path, EXAMPLE_GAP)) == 0
+
+    def test_few_instructions_not_flagged(self, tmp_path: Path) -> None:
+        body = "Some background context about the project.\n" * 10
+        path = _make_skill(tmp_path, "e4", body)
+        assert len(_findings_for(path, EXAMPLE_GAP)) == 0
+
+
+# --- StaleReferences ---
+
+
+class TestStaleReferences:
+    def test_gpt35_turbo(self, tmp_path: Path) -> None:
+        path = _make_skill(tmp_path, "st1", "Use gpt-3.5-turbo for summarization.")
+        assert STALE in _rule_ids(path)
+
+    def test_text_davinci(self, tmp_path: Path) -> None:
+        path = _make_skill(tmp_path, "st2", "Use text-davinci-003 for completions.")
+        assert STALE in _rule_ids(path)
+
+    def test_claude_v1(self, tmp_path: Path) -> None:
+        path = _make_skill(tmp_path, "st3", "Use claude-v1 for this task.")
+        assert STALE in _rule_ids(path)
+
+    def test_claude_2(self, tmp_path: Path) -> None:
+        path = _make_skill(tmp_path, "st4", "Use claude-2.1 as the model.")
+        assert STALE in _rule_ids(path)
+
+    def test_tslint(self, tmp_path: Path) -> None:
+        path = _make_skill(tmp_path, "st5", "Run tslint before committing.")
+        assert STALE in _rule_ids(path)
+
+    def test_create_react_app(self, tmp_path: Path) -> None:
+        path = _make_skill(tmp_path, "st6", "Bootstrap with create-react-app.")
+        assert STALE in _rule_ids(path)
+
+    def test_python_37(self, tmp_path: Path) -> None:
+        path = _make_skill(tmp_path, "st7", "Requires Python 3.7 or higher.")
+        assert STALE in _rule_ids(path)
+
+    def test_current_model_no_flag(self, tmp_path: Path) -> None:
+        path = _make_skill(tmp_path, "st8", "Use claude-sonnet-4-6 for code generation.")
+        assert len(_findings_for(path, STALE)) == 0
+
+    def test_no_flag_in_code_block(self, tmp_path: Path) -> None:
+        body = "```\n# legacy: text-davinci-003\n```"
+        path = _make_skill(tmp_path, "st9", body)
+        assert len(_findings_for(path, STALE)) == 0
+
+    def test_modern_tools_no_flag(self, tmp_path: Path) -> None:
+        path = _make_skill(tmp_path, "st10", "Use eslint with @typescript-eslint.")
+        assert len(_findings_for(path, STALE)) == 0
+
+    def test_includes_replacement(self, tmp_path: Path) -> None:
+        path = _make_skill(tmp_path, "st11", "Run tslint on all files.")
+        msgs = [d.message for d in _findings_for(path, STALE)]
+        assert any("@typescript-eslint" in m for m in msgs)


### PR DESCRIPTION
## Summary

- Adds 5 new deterministic lint rules under `quality/` that check whether instructions will actually work well with an LLM
- Includes 56 tests, preset configuration, shared pattern module, and future plan spec
- Rule count: 43 -> 48, version bumped to 3.7.0

### New rules

| Rule | What it checks |
|------|---------------|
| `quality/imprecise-instruction` | Hedging ("try to"), passive voice ("should be run"), vague conditions ("if appropriate") |
| `quality/redundant-guidance` | Instructions redundant with model defaults or project tooling config (.editorconfig, .prettierrc, etc.) |
| `quality/unfinished-content` | Placeholders, TODO/FIXME, deferred content (TBD, coming soon), empty markdown sections |
| `quality/example-gap` | Skills with many instructions but no code examples |
| `quality/stale-references` | Deprecated models (text-davinci, claude-v1), sunset APIs, outdated tools (tslint, create-react-app) |

## Test plan

- [x] 56 new tests pass (positive matches + false-positive prevention)
- [x] Full suite: 313 tests pass, no regressions
- [x] Lint and format clean
- [x] Dogfood: zero false positives on the project's own setup