### PR TITLE
fix: offline-safe token counting and correct orphan detection scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- Token counting no longer crashes in air-gapped or egress-restricted environments. Falls back to chars/4 heuristic when tiktoken cannot download the cl100k_base BPE file, with a one-time warning.
+- Orphan detection no longer flags unreferenced skills. Skills are activated by description matching, not explicit references, so an unreferenced skill is healthy. Orphan detection is now scoped to commands and agents only.
+
 ## [4.0.0] - 2026-07-08
 
 ### Changed

--- a/src/setup_eval/analysis/dependencies.py
+++ b/src/setup_eval/analysis/dependencies.py
@@ -95,9 +95,11 @@ def analyze_dependencies(setup: Setup) -> DependencyReport:
         referenced_names.add(e.source_name)
 
     orphans = []
+    # Skills are activated by description matching, not by explicit references,
+    # so an unreferenced skill is not orphaned. Only flag commands and agents.
+    orphan_types = (ComponentType.COMMAND, ComponentType.AGENT)
     for comp in setup.components:
-        skip_types = (ComponentType.CLAUDE_MD, ComponentType.HOOKS, ComponentType.MCP_CONFIG)
-        if comp.component_type in skip_types:
+        if comp.component_type not in orphan_types:
             continue
         if comp.name not in referenced_names and len(setup.components) > 3:
             orphans.append(f"{comp.component_type.value}/{comp.name}")

--- a/src/setup_eval/utils/tokens.py
+++ b/src/setup_eval/utils/tokens.py
@@ -1,18 +1,57 @@
-"""Token counting via tiktoken."""
+"""Token counting with offline-safe fallback.
+
+Uses tiktoken's cl100k_base encoding when available. Falls back to a
+chars/4 heuristic if tiktoken fails to load (e.g. air-gapped CI runners
+where the BPE file cannot be downloaded from OpenAI's CDN).
+
+Note: cl100k_base is OpenAI's tokenizer. Token counts are approximations
+for non-OpenAI models (Claude, Gemini, etc.).
+"""
 
 from __future__ import annotations
 
-import tiktoken
+import logging
+import warnings
 
-_ENCODER: tiktoken.Encoding | None = None
+_log = logging.getLogger(__name__)
+
+_ENCODER = None
+_FALLBACK = False
+_WARNED = False
 
 
-def _get_encoder() -> tiktoken.Encoding:
-    global _ENCODER
-    if _ENCODER is None:
+def _init_encoder():
+    global _ENCODER, _FALLBACK
+    try:
+        import tiktoken
+
         _ENCODER = tiktoken.get_encoding("cl100k_base")
-    return _ENCODER
+    except Exception:
+        _FALLBACK = True
+        _log.debug("tiktoken unavailable, using chars/4 heuristic for token counts")
+
+
+def _reset():
+    """Reset module state. Used by tests only."""
+    global _ENCODER, _FALLBACK, _WARNED
+    _ENCODER = None
+    _FALLBACK = False
+    _WARNED = False
 
 
 def count_tokens(text: str) -> int:
-    return len(_get_encoder().encode(text))
+    global _WARNED
+
+    if _ENCODER is None and not _FALLBACK:
+        _init_encoder()
+
+    if _ENCODER is not None:
+        return len(_ENCODER.encode(text))
+
+    if not _WARNED:
+        warnings.warn(
+            "tiktoken not available; token counts use chars/4 approximation",
+            stacklevel=2,
+        )
+        _WARNED = True
+    return len(text) // 4

--- a/tests/test_ci_readiness.py
+++ b/tests/test_ci_readiness.py
@@ -1,0 +1,114 @@
+"""Tests for CI readiness fixes: tiktoken fallback and orphan detection scope."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from setup_eval.analysis.dependencies import analyze_dependencies
+from setup_eval.core.types import ComponentType, ParsedComponent, Setup
+from setup_eval.utils import tokens
+
+
+class TestTiktokenFallback:
+    """Token counting must work when tiktoken is unavailable."""
+
+    def setup_method(self):
+        tokens._reset()
+
+    def teardown_method(self):
+        tokens._reset()
+
+    def test_fallback_returns_chars_div_4(self):
+        with patch.object(tokens, "_init_encoder", side_effect=self._force_fallback):
+            result = tokens.count_tokens("hello world! this is a test.")
+            assert result == len("hello world! this is a test.") // 4
+
+    def test_fallback_warns_once(self):
+        with patch.object(tokens, "_init_encoder", side_effect=self._force_fallback):
+            with pytest.warns(UserWarning, match="chars/4 approximation"):
+                tokens.count_tokens("first call")
+            tokens.count_tokens("second call")
+
+    def test_normal_path_uses_tiktoken(self):
+        # Reset to ensure fresh init
+        tokens._reset()
+        result = tokens.count_tokens("hello world")
+        assert isinstance(result, int)
+        assert result > 0
+
+    def test_empty_string(self):
+        assert tokens.count_tokens("") == 0
+
+    @staticmethod
+    def _force_fallback():
+        tokens._FALLBACK = True
+
+
+class TestOrphanDetectionScope:
+    """Orphan detection must not flag unreferenced skills."""
+
+    @staticmethod
+    def _make_setup(components: list[ParsedComponent]) -> Setup:
+        return Setup(
+            name="test",
+            path="/tmp/test",
+            fingerprint="test-fingerprint",
+            components=components,
+        )
+
+    @staticmethod
+    def _make_component(name: str, ctype: ComponentType, content: str = "") -> ParsedComponent:
+        return ParsedComponent(
+            name=name,
+            component_type=ctype,
+            path=f"/tmp/test/{name}",
+            content=content,
+        )
+
+    def test_unreferenced_skill_not_orphaned(self):
+        components = [
+            self._make_component("my-skill", ComponentType.SKILL, "does things"),
+            self._make_component("other-skill", ComponentType.SKILL, "does other things"),
+            self._make_component("a-command", ComponentType.COMMAND, "runs stuff"),
+            self._make_component("main", ComponentType.CLAUDE_MD, "instructions"),
+        ]
+        setup = self._make_setup(components)
+        deps = analyze_dependencies(setup)
+        orphan_names = [o.split("/")[-1] for o in deps.orphan_components]
+        assert "my-skill" not in orphan_names
+        assert "other-skill" not in orphan_names
+
+    def test_unreferenced_command_is_orphaned(self):
+        components = [
+            self._make_component("my-skill", ComponentType.SKILL, "does things"),
+            self._make_component("other-skill", ComponentType.SKILL, "does other things"),
+            self._make_component("lonely-command", ComponentType.COMMAND, "nobody calls me"),
+            self._make_component("main", ComponentType.CLAUDE_MD, "instructions"),
+        ]
+        setup = self._make_setup(components)
+        deps = analyze_dependencies(setup)
+        orphan_names = [o.split("/")[-1] for o in deps.orphan_components]
+        assert "lonely-command" in orphan_names
+
+    def test_referenced_command_not_orphaned(self):
+        components = [
+            self._make_component("my-skill", ComponentType.SKILL, "uses skill 'used-command'"),
+            self._make_component("used-command", ComponentType.COMMAND, "i am used"),
+            self._make_component("other-skill", ComponentType.SKILL, "more stuff"),
+            self._make_component("main", ComponentType.CLAUDE_MD, "instructions"),
+        ]
+        setup = self._make_setup(components)
+        deps = analyze_dependencies(setup)
+        orphan_names = [o.split("/")[-1] for o in deps.orphan_components]
+        assert "used-command" not in orphan_names
+
+    def test_small_setup_skips_orphan_check(self):
+        components = [
+            self._make_component("lonely-command", ComponentType.COMMAND, "nobody calls me"),
+            self._make_component("main", ComponentType.CLAUDE_MD, "instructions"),
+        ]
+        setup = self._make_setup(components)
+        deps = analyze_dependencies(setup)
+        assert len(deps.orphan_components) == 0


### PR DESCRIPTION
## Summary

Two fixes to prepare setup-eval for CI pipeline adoption.

### 1. Token counting crashes in air-gapped environments

`tiktoken.get_encoding("cl100k_base")` downloads a BPE file from OpenAI's CDN on first use. In CI runners with restricted egress (common in security-conscious orgs), this hard-crashes the tool with a network error. The "fully offline" claim for lint does not hold.

**Fix:** Wrap the tiktoken initialization in a try/except. If it fails, fall back to a `len(text) // 4` heuristic with a one-time warning. Token counts become approximations, but the tool runs instead of crashing.

Also documents that cl100k_base is OpenAI's tokenizer, so counts are approximations for Claude/Gemini regardless.

### 2. Orphan detection incorrectly flags skills

The dependency analysis flags components as "orphaned" if no other component references them. This is correct for commands and agents (which are explicitly invoked), but wrong for skills. Skills are activated by description matching at runtime, not by explicit references in other files. A skill that no other file mentions is not orphaned; it is healthy and working as designed.

**Fix:** Scope orphan detection to commands and agents only. Skills are excluded from the orphan check.

## Test plan

- [ ] `uv run pytest tests/ -q` passes (400 tests)
- [ ] `uv run ruff check src/ tests/` clean
- [ ] `uv run ruff format --check src/ tests/` clean
- [ ] Manual: `TIKTOKEN_CACHE_DIR=/nonexistent setup-eval lint .` completes with a warning instead of crashing