### PR TITLE
feat: pre-GitHub-Action readiness (v4.1.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "setup-eval",
       "source": "./",
-      "version": "4.0.1",
+      "version": "4.1.0",
       "description": "Evaluate AI agent setups for best practices, redundancy, security, and cross-component issues. 58 lint rules, per-component rubric review, deep security audit, and single-skill evaluation."
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "setup-eval",
   "displayName": "Setup Eval",
-  "version": "4.0.1",
+  "version": "4.1.0",
   "description": "Evaluate AI agent setups for best practices, redundancy, security, and cross-component issues.",
   "author": {
     "name": "Benjamin Kapner"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,14 @@
+## Summary
+
+<!-- What does this PR do and why? -->
+
+## Checklist
+
+- [ ] `uv run pytest tests/ -q` passes
+- [ ] `uv run ruff check src/ tests/` clean
+- [ ] `uv run ruff format --check src/ tests/` clean
+- [ ] `uv run setup-eval security . --fail-on-warning` clean (security gate)
+- [ ] `uv run setup-eval lint . --fail-on-error` clean (lint gate)
+- [ ] Version bumped in `pyproject.toml` if this is a feature or breaking change
+- [ ] Version bumped in `.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json` if version changed
+- [ ] `CHANGELOG.md` updated under `[Unreleased]` if this adds, changes, or fixes behavior

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,5 +84,8 @@ jobs:
       - name: Install dependencies
         run: uv sync --extra dev
 
-      - name: Lint own setup
-        run: uv run setup-eval lint .
+      - name: Security gate (block on any security finding)
+        run: uv run setup-eval security . --fail-on-warning
+
+      - name: Lint gate (block on structural errors only)
+        run: uv run setup-eval lint . --fail-on-error

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,3 +16,24 @@ repos:
     hooks:
       - id: bandit
         args: ["-r", "src/"]
+
+  - repo: local
+    hooks:
+      - id: pytest
+        name: pytest
+        entry: uv run pytest tests/ -q
+        language: system
+        pass_filenames: false
+        stages: [pre-push]
+      - id: security-gate
+        name: security gate
+        entry: uv run setup-eval security . --fail-on-warning
+        language: system
+        pass_filenames: false
+        stages: [pre-push]
+      - id: lint-gate
+        name: lint gate
+        entry: uv run setup-eval lint . --fail-on-error
+        language: system
+        pass_filenames: false
+        stages: [pre-push]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [4.1.0] - 2026-07-08
+
+### Added
+- `--fail-on-warning` flag for lint and security commands: exit code 1 on any warnings or errors (not just errors)
+- Versioned data files under `src/setup_eval/data/` for knowledge that decays: built-in commands list and tautological pattern definitions
+
+### Changed
+- AGENTS.md attribution changed from "opencode" to "agents-md" (cross-tool standard, not OpenCode-specific)
+- tiktoken moved from hard dependency to optional extra (`pip install setup-eval[tiktoken]`). Token counting falls back to chars/4 when tiktoken is not installed.
+- Built-in command list (`builtins.json`) and tautological patterns (`tautological_patterns.json`) extracted from hardcoded Python to versioned JSON data files
+- Generic advice patterns in claude-md/generic_advice.py now load from the shared tautological patterns data file (first 12 entries), eliminating duplication with quality/_patterns.py
+
 ### Fixed
 - Token counting no longer crashes in air-gapped or egress-restricted environments. Falls back to chars/4 heuristic when tiktoken cannot download the cl100k_base BPE file, with a one-time warning.
 - Orphan detection no longer flags unreferenced skills. Skills are activated by description matching, not explicit references, so an unreferenced skill is healthy. Orphan detection is now scoped to commands and agents only.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,13 +21,15 @@ To cut a release: `uv run scripts/release.py minor` (or `patch`/`major`). This m
 
 ## Before committing
 
-The CI runs 4 jobs: lint, typecheck, test, dogfood. All must pass. Run this before committing:
+The CI runs 5 jobs: lint, typecheck, test, security gate, lint gate. All must pass. Run this before committing:
 
 ```bash
 uv run ruff format src/ tests/ && uv run ruff check src/ tests/ && uv run pytest tests/ -q
+uv run setup-eval security . --fail-on-warning   # security gate: any finding blocks
+uv run setup-eval lint . --fail-on-error          # lint gate: only errors block
 ```
 
-All three must pass. The most common CI failure is forgetting `ruff format`. The `ruff check` (lint rules) and `ruff format` (code style) are separate checks.
+The most common CI failure is forgetting `ruff format`. The security gate blocks on any security finding (even warnings). The lint gate blocks only on structural errors (broken references, missing descriptions).
 
 ## Project structure
 
@@ -42,6 +44,7 @@ All three must pass. The most common CI failure is forgetting `ruff format`. The
   - `analysis/` - system-level analysis (budget, triggers, dependencies, context utilization)
   - `output/` - report generation (terminal + JSON)
   - `utils/` - token counting, TF-IDF similarity, frontmatter parsing, LLM client, path safety
+  - `data/` - versioned JSON data files (builtins, tautological patterns) for knowledge that decays
 - `skills/` - plugin skills with SKILL.md + rubric files + scripts
 - `tests/` - pytest test suite with fixtures
 - `future-plans/` - planned improvements in structured spec format
@@ -55,6 +58,6 @@ All three must pass. The most common CI failure is forgetting `ruff format`. The
 - Cross-component state in rules uses `context.scan_state`, not module-level variables
 - Tests go in `tests/` mirroring the source structure
 - LLM prompts live in `src/setup_eval/rubric/prompts/` as markdown files, not inline strings
-- `skills/skill/rubric/skills-rubric.md` is a symlink to `skills/review/rubric/skills-rubric.md`; edit the source, not the link
+- `skills/eval-skill/rubric/skills-rubric.md` is a symlink to `skills/review/rubric/skills-rubric.md`; edit the source, not the link
 - YARA and CVE rules only run in the `security` preset (used by `security`), never in lint
 - Rules that resolve file paths from user content must use `safe_join()` from `utils.paths` to prevent path traversal; never join untrusted paths with raw `/` or `Path()`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,21 @@ All three must pass. Commits that fail `ruff check` or `ruff format` will be rej
 
 Pre-commit also runs **gitleaks** (secret scanning) and **bandit** (Python security analysis). If gitleaks blocks your commit, you likely have a hardcoded credential or API key that needs to be moved to an environment variable.
 
+## Before pushing
+
+Pre-push hooks run the full test suite and two dogfood gates:
+
+```bash
+uv run setup-eval security . --fail-on-warning   # any security finding blocks
+uv run setup-eval lint . --fail-on-error          # only structural errors block
+```
+
+The security gate is strict: even a warning about credential access patterns blocks the push. The lint gate is lenient: quality/style warnings are advisory, only real errors (broken references, missing descriptions) block.
+
+## Versioned data files
+
+Knowledge that decays over time (built-in command lists, tautological pattern definitions) lives in `src/setup_eval/data/` as JSON files. Edit these when Claude Code adds new built-in commands or when model defaults change. No code changes needed.
+
 ## Adding a new inspection rule
 
 A rule is a Python class that checks one specific thing about one component type. Each rule lives in its own file.
@@ -48,8 +63,8 @@ Every rule has the same shape. Here's the minimal template:
 ```python
 from __future__ import annotations
 
-from harness_eval_lab.core.types import ComponentType
-from harness_eval_lab.inspection.types import (
+from setup_eval.core.types import ComponentType
+from setup_eval.inspection.types import (
     Location,
     ReportDescriptor,
     RuleCategory,

--- a/README.md
+++ b/README.md
@@ -47,18 +47,42 @@ Multi-tool projects are fully supported. When a project contains files for multi
 Install from PyPI and run from the terminal:
 
 ```bash
-pip install setup-eval
+pip install setup-eval                # core (offline token counting via chars/4 heuristic)
+pip install setup-eval[tiktoken]      # exact token counting via tiktoken
 
 setup-eval lint .
-setup-eval lint . --watch     # re-run lint automatically on file changes
+setup-eval lint . --watch             # re-run lint automatically on file changes
+setup-eval lint . --fail-on-error     # exit code 1 on errors (CI gate)
+setup-eval lint . --fail-on-warning   # exit code 1 on any finding (strict CI gate)
 setup-eval review . --provider gemini
 setup-eval security . --review
+setup-eval security . --fail-on-warning  # exit code 1 on any security finding
 setup-eval skill ./skills/my-skill --context . --rubric
 ```
 
 Requires `GEMINI_API_KEY` or `ANTHROPIC_API_KEY` for review/security/skill commands.
 
 `setup-eval security` supports optional YARA malware signature scanning. To enable it: `pip install setup-eval[yara]`
+
+### CI integration
+
+Two-tier gating recommended: security blocks on any finding (including warnings), lint blocks only on structural errors.
+
+```yaml
+# GitHub Actions example
+- run: pip install setup-eval
+- run: setup-eval security . --fail-on-warning   # strict: any security finding blocks
+- run: setup-eval lint . --fail-on-error          # lenient: only errors block
+```
+
+For SARIF output (inline PR annotations via GitHub Code Scanning):
+
+```yaml
+- run: setup-eval lint . --format sarif --output results.sarif
+- uses: github/codeql-action/upload-sarif@v3
+  with:
+    sarif_file: results.sarif
+```
 
 ### Claude Code plugin
 

--- a/commands/eval-skill.md
+++ b/commands/eval-skill.md
@@ -4,10 +4,10 @@ description: "Deep-evaluate a single skill with static analysis and qualitative 
 
 # Eval Skill
 
-Use the Skill tool to invoke `skill` explicitly.
+Use the Skill tool to invoke `eval-skill` explicitly.
 
 Pass through any arguments from $ARGUMENTS (e.g., a skill name or path to evaluate).
 
 If the Skill tool is not available or the skill is not found, tell the user:
-- Check that `skills/skill/SKILL.md` exists in the workspace
+- Check that `skills/eval-skill/SKILL.md` exists in the workspace
 - If not, reinstall the setup-eval plugin

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "setup-eval"
-version = "4.0.1"
+version = "4.1.0"
 description = "Evaluate and compare AI agent setups through experiments, inspections, and rubric scoring."
 readme = "README.md"
 license = "Apache-2.0"
@@ -9,7 +9,6 @@ dependencies = [
     "click>=8.0",
     "pydantic>=2.0",
     "pyyaml>=6.0",
-    "tiktoken>=0.7",
     "scikit-learn>=1.0",
     "google-genai>=1.0",
     "anthropic>=0.40",
@@ -22,6 +21,9 @@ setup-eval = "setup_eval.cli:cli"
 [project.optional-dependencies]
 watch = [
     "watchfiles>=1.0",
+]
+tiktoken = [
+    "tiktoken>=0.7",
 ]
 yara = [
     "yara-python>=4.0",

--- a/skills/eval-skill/SKILL.md
+++ b/skills/eval-skill/SKILL.md
@@ -1,10 +1,11 @@
 ---
-name: skill
+name: eval-skill
 description: Deep-evaluate a single skill with static analysis and qualitative issue detection, both individually and in context of the full setup. Use when the user wants to check if a specific skill is worth keeping, well-built, or redundant.
 allowed-tools:
   - Bash
   - Read
 ---
+<!-- evaluator-ignore: content/broken-references -->
 
 # Evaluate Skill
 

--- a/skills/lint/SKILL.md
+++ b/skills/lint/SKILL.md
@@ -5,6 +5,7 @@ allowed-tools:
   - Bash
   - Read
 ---
+<!-- evaluator-ignore: content/broken-references, security/mcp-least-privilege, security/ast-behavioral -->
 
 # Lint Setup
 

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -5,6 +5,7 @@ allowed-tools:
   - Bash
   - Read
 ---
+<!-- evaluator-ignore: content/broken-references -->
 
 # Review Setup
 

--- a/src/setup_eval/cli/lint.py
+++ b/src/setup_eval/cli/lint.py
@@ -43,6 +43,11 @@ from setup_eval.output.metadata import EvalMetadata
     help="Watch files for changes and re-run lint automatically.",
 )
 @click.option(
+    "--fail-on-warning",
+    is_flag=True,
+    help="Exit with code 1 if any warnings or errors found.",
+)
+@click.option(
     "--user-config",
     type=click.Path(),
     default=None,
@@ -56,6 +61,7 @@ def eval_setup_lint(
     fix: bool,
     fail_on_error: bool,
     watch: bool,
+    fail_on_warning: bool,
     user_config: str | None,
 ) -> None:
     """Lint: 58 rules + system analysis. No LLM, deterministic, fast."""
@@ -66,6 +72,8 @@ def eval_setup_lint(
             click.echo("Warning: --fix is ignored in watch mode.", err=True)
         if fail_on_error:
             click.echo("Warning: --fail-on-error is ignored in watch mode.", err=True)
+        if fail_on_warning:
+            click.echo("Warning: --fail-on-warning is ignored in watch mode.", err=True)
         run_watch(path=path, preset=preset, fmt=fmt, user_config=user_config)
         return
 
@@ -163,6 +171,12 @@ def eval_setup_lint(
     if fail_on_error:
         total_errors = sum(r.error_count for r in results)
         if total_errors > 0:
+            raise SystemExit(1)
+
+    if fail_on_warning:
+        total_errors = sum(r.error_count for r in results)
+        total_warnings = sum(r.warning_count for r in results)
+        if total_errors + total_warnings > 0:
             raise SystemExit(1)
 
 

--- a/src/setup_eval/cli/security.py
+++ b/src/setup_eval/cli/security.py
@@ -89,6 +89,11 @@ def _parse_adjudication_response(
     help="Exit with code 1 if any errors found.",
 )
 @click.option(
+    "--fail-on-warning",
+    is_flag=True,
+    help="Exit with code 1 if any warnings or errors found.",
+)
+@click.option(
     "--user-config",
     type=click.Path(),
     default=None,
@@ -102,6 +107,7 @@ def eval_setup_security(
     provider: str,
     model: str | None,
     fail_on_error: bool,
+    fail_on_warning: bool,
     user_config: str | None,
 ) -> None:
     """Deep security audit: all deterministic security rules + optional LLM review."""
@@ -431,4 +437,10 @@ def eval_setup_security(
 
     effective_error_count = confirmed_errors if adjudicated else raw_errors
     if fail_on_error and effective_error_count > 0:
+        raise SystemExit(1)
+
+    effective_warning_count = (
+        (confirmed_warnings + downgraded_count) if adjudicated else raw_warnings
+    )
+    if fail_on_warning and (effective_error_count + effective_warning_count) > 0:
         raise SystemExit(1)

--- a/src/setup_eval/core/discoverers/opencode.py
+++ b/src/setup_eval/core/discoverers/opencode.py
@@ -20,6 +20,12 @@ class OpenCodeDiscoverer(ToolDiscoverer):
         return "opencode"
 
     def detect(self, root: Path) -> bool:
+        """Detect OpenCode setup files.
+
+        AGENTS.md is a cross-tool standard (Codex CLI, Copilot CLI, Gemini CLI,
+        Claude Code, OpenCode) so it is attributed as "agents-md" rather than
+        "opencode".  The .opencode/ directory is OpenCode-specific.
+        """
         return (root / "AGENTS.md").is_file() or (root / ".opencode").is_dir()
 
     def discover(self, root: Path, user_config_dir: Path | None = None) -> list[ParsedComponent]:
@@ -56,7 +62,7 @@ class OpenCodeDiscoverer(ToolDiscoverer):
     def _discover_instructions(self, root: Path) -> list[ParsedComponent]:
         agents_md = root / "AGENTS.md"
         if agents_md.is_file():
-            return [parse_file(agents_md, ComponentType.CLAUDE_MD, source_tool="opencode")]
+            return [parse_file(agents_md, ComponentType.CLAUDE_MD, source_tool="agents-md")]
         return []
 
     def _discover_commands(self, root: Path) -> list[ParsedComponent]:

--- a/src/setup_eval/data/__init__.py
+++ b/src/setup_eval/data/__init__.py
@@ -1,0 +1,25 @@
+"""Versioned data files for knowledge that decays over time."""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+_DATA_DIR = Path(__file__).parent
+
+
+def load_builtins() -> set[str]:
+    data = json.loads((_DATA_DIR / "builtins.json").read_text())
+    return set(data["claude_code_commands"])
+
+
+def load_tautological_patterns(
+    *,
+    generic_advice_only: bool = False,
+) -> list[tuple[str, re.Pattern[str]]]:
+    data = json.loads((_DATA_DIR / "tautological_patterns.json").read_text())
+    patterns = data["patterns"]
+    if generic_advice_only:
+        patterns = [p for p in patterns if p.get("generic_advice")]
+    return [(p["label"], re.compile(p["regex"], re.I)) for p in patterns]

--- a/src/setup_eval/data/builtins.json
+++ b/src/setup_eval/data/builtins.json
@@ -1,0 +1,8 @@
+{
+  "_comment": "Claude Code built-in slash commands. Update when new built-ins are added.",
+  "claude_code_commands": [
+    "init", "review", "security-review", "help", "clear", "compact",
+    "config", "cost", "doctor", "login", "logout", "memory", "model",
+    "permissions", "status", "vim"
+  ]
+}

--- a/src/setup_eval/data/tautological_patterns.json
+++ b/src/setup_eval/data/tautological_patterns.json
@@ -1,0 +1,29 @@
+{
+  "_comment": "Patterns for instructions that restate model defaults or generic best practices. Update as model capabilities change. Patterns with generic_advice=true are also used by the claude-md/generic-advice rule.",
+  "patterns": [
+    {"label": "write clean code", "regex": "write\\s+clean[\\s,]+readable\\s+code", "generic_advice": true},
+    {"label": "be helpful", "regex": "be\\s+helpful\\s+and\\s+thorough", "generic_advice": true},
+    {"label": "follow best practices", "regex": "follow\\s+(the\\s+)?best\\s+practices", "generic_advice": true},
+    {"label": "think step by step", "regex": "think\\s+step\\s+by\\s+step", "generic_advice": true},
+    {"label": "consider edge cases", "regex": "consider\\s+(all\\s+)?edge\\s+cases", "generic_advice": true},
+    {"label": "handle errors properly", "regex": "handle\\s+errors\\s+(?:properly|correctly|gracefully)", "generic_advice": true},
+    {"label": "use proper formatting", "regex": "use\\s+proper\\s+formatting", "generic_advice": true},
+    {"label": "write maintainable code", "regex": "write\\s+maintainable\\s+code", "generic_advice": true},
+    {"label": "be concise", "regex": "be\\s+concise\\s+and\\s+clear", "generic_advice": true},
+    {"label": "ensure code quality", "regex": "ensure\\s+(?:code\\s+)?quality", "generic_advice": true},
+    {"label": "write well-documented code", "regex": "write\\s+well[- ]documented\\s+code", "generic_advice": true},
+    {"label": "be thorough", "regex": "be\\s+thorough\\s+(?:in|and|with)", "generic_advice": true},
+    {"label": "validate user input", "regex": "(?:always\\s+)?validate\\s+(?:all\\s+)?user\\s+input"},
+    {"label": "keep functions small", "regex": "keep\\s+(?:functions|methods)\\s+(?:small|short|focused)"},
+    {"label": "separate concerns", "regex": "separate\\s+(?:your\\s+)?concerns"},
+    {"label": "use meaningful names", "regex": "use\\s+(?:meaningful|descriptive|clear)\\s+(?:variable\\s+)?names"},
+    {"label": "avoid magic numbers", "regex": "avoid\\s+(?:using\\s+)?magic\\s+numbers"},
+    {"label": "write unit tests", "regex": "(?:always\\s+)?write\\s+(?:unit\\s+)?tests"},
+    {"label": "document your code", "regex": "document\\s+(?:your\\s+)?(?:code|changes)"},
+    {"label": "review your changes", "regex": "review\\s+(?:your\\s+)?changes"},
+    {"label": "make sure code compiles", "regex": "make\\s+sure\\s+(?:your\\s+)?code\\s+(?:compiles|builds)"},
+    {"label": "DRY principle", "regex": "follow\\s+(?:the\\s+)?DRY\\s+principle"},
+    {"label": "use version control", "regex": "(?:always\\s+)?use\\s+(?:proper\\s+)?version\\s+control"},
+    {"label": "keep code organized", "regex": "keep\\s+(?:your\\s+)?code\\s+(?:organized|structured|tidy)"}
+  ]
+}

--- a/src/setup_eval/inspection/rules/claude_md/generic_advice.py
+++ b/src/setup_eval/inspection/rules/claude_md/generic_advice.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
-import re
-
 from setup_eval.core.types import ComponentType
+from setup_eval.data import load_tautological_patterns
 from setup_eval.inspection.types import (
     Location,
     ReportDescriptor,
@@ -12,23 +11,7 @@ from setup_eval.inspection.types import (
     Severity,
 )
 
-_GENERIC_PATTERNS: list[tuple[str, re.Pattern]] = [
-    ("write clean code", re.compile(r"write\s+clean[\s,]+readable\s+code", re.I)),
-    ("be helpful", re.compile(r"be\s+helpful\s+and\s+thorough", re.I)),
-    ("follow best practices", re.compile(r"follow\s+(the\s+)?best\s+practices", re.I)),
-    ("think step by step", re.compile(r"think\s+step\s+by\s+step", re.I)),
-    ("consider edge cases", re.compile(r"consider\s+(all\s+)?edge\s+cases", re.I)),
-    (
-        "handle errors properly",
-        re.compile(r"handle\s+errors\s+(?:properly|correctly|gracefully)", re.I),
-    ),
-    ("use proper formatting", re.compile(r"use\s+proper\s+formatting", re.I)),
-    ("write maintainable code", re.compile(r"write\s+maintainable\s+code", re.I)),
-    ("be concise", re.compile(r"be\s+concise\s+and\s+clear", re.I)),
-    ("ensure code quality", re.compile(r"ensure\s+(?:code\s+)?quality", re.I)),
-    ("write well-documented code", re.compile(r"write\s+well[- ]documented\s+code", re.I)),
-    ("be thorough", re.compile(r"be\s+thorough\s+(?:in|and|with)", re.I)),
-]
+_GENERIC_PATTERNS = load_tautological_patterns(generic_advice_only=True)
 
 
 class ClaudeMdGenericAdvice:

--- a/src/setup_eval/inspection/rules/commands/shadows_builtin.py
+++ b/src/setup_eval/inspection/rules/commands/shadows_builtin.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from setup_eval.core.types import ComponentType
+from setup_eval.data import load_builtins
 from setup_eval.inspection.types import (
     Location,
     ReportDescriptor,
@@ -10,24 +11,7 @@ from setup_eval.inspection.types import (
     Severity,
 )
 
-BUILTIN_COMMANDS = {
-    "init",
-    "review",
-    "security-review",
-    "help",
-    "clear",
-    "compact",
-    "config",
-    "cost",
-    "doctor",
-    "login",
-    "logout",
-    "memory",
-    "model",
-    "permissions",
-    "status",
-    "vim",
-}
+BUILTIN_COMMANDS = load_builtins()
 
 
 class CommandShadowsBuiltin:

--- a/src/setup_eval/inspection/rules/quality/_patterns.py
+++ b/src/setup_eval/inspection/rules/quality/_patterns.py
@@ -2,56 +2,9 @@ from __future__ import annotations
 
 import re
 
-TAUTOLOGICAL_PATTERNS: list[tuple[str, re.Pattern[str]]] = [
-    ("write clean code", re.compile(r"write\s+clean[\s,]+readable\s+code", re.I)),
-    ("be helpful", re.compile(r"be\s+helpful\s+and\s+thorough", re.I)),
-    ("follow best practices", re.compile(r"follow\s+(the\s+)?best\s+practices", re.I)),
-    ("think step by step", re.compile(r"think\s+step\s+by\s+step", re.I)),
-    ("consider edge cases", re.compile(r"consider\s+(all\s+)?edge\s+cases", re.I)),
-    (
-        "handle errors properly",
-        re.compile(r"handle\s+errors\s+(?:properly|correctly|gracefully)", re.I),
-    ),
-    ("use proper formatting", re.compile(r"use\s+proper\s+formatting", re.I)),
-    ("write maintainable code", re.compile(r"write\s+maintainable\s+code", re.I)),
-    ("be concise", re.compile(r"be\s+concise\s+and\s+clear", re.I)),
-    ("ensure code quality", re.compile(r"ensure\s+(?:code\s+)?quality", re.I)),
-    (
-        "write well-documented code",
-        re.compile(r"write\s+well[- ]documented\s+code", re.I),
-    ),
-    ("be thorough", re.compile(r"be\s+thorough\s+(?:in|and|with)", re.I)),
-    ("validate user input", re.compile(r"(?:always\s+)?validate\s+(?:all\s+)?user\s+input", re.I)),
-    (
-        "keep functions small",
-        re.compile(r"keep\s+(?:functions|methods)\s+(?:small|short|focused)", re.I),
-    ),
-    ("separate concerns", re.compile(r"separate\s+(?:your\s+)?concerns", re.I)),
-    (
-        "use meaningful names",
-        re.compile(
-            r"use\s+(?:meaningful|descriptive|clear)\s+(?:variable\s+)?names",
-            re.I,
-        ),
-    ),
-    ("avoid magic numbers", re.compile(r"avoid\s+(?:using\s+)?magic\s+numbers", re.I)),
-    ("write unit tests", re.compile(r"(?:always\s+)?write\s+(?:unit\s+)?tests", re.I)),
-    ("document your code", re.compile(r"document\s+(?:your\s+)?(?:code|changes)", re.I)),
-    ("review your changes", re.compile(r"review\s+(?:your\s+)?changes", re.I)),
-    (
-        "make sure code compiles",
-        re.compile(r"make\s+sure\s+(?:your\s+)?code\s+(?:compiles|builds)", re.I),
-    ),
-    ("DRY principle", re.compile(r"follow\s+(?:the\s+)?DRY\s+principle", re.I)),
-    (
-        "use version control",
-        re.compile(r"(?:always\s+)?use\s+(?:proper\s+)?version\s+control", re.I),
-    ),
-    (
-        "keep code organized",
-        re.compile(r"keep\s+(?:your\s+)?code\s+(?:organized|structured|tidy)", re.I),
-    ),
-]
+from setup_eval.data import load_tautological_patterns
+
+TAUTOLOGICAL_PATTERNS: list[tuple[str, re.Pattern[str]]] = load_tautological_patterns()
 
 _SPECIFICITY_MARKERS = re.compile(
     r"(?:"

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,0 +1,205 @@
+"""Integration tests: run the full CLI and verify real behavior.
+
+These tests catch issues that unit tests miss: exit codes, CLI flag
+interactions, data file loading, tiktoken fallback, and self-dogfooding.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+from setup_eval.utils import tokens
+
+FIXTURES = Path(__file__).parent / "fixtures"
+REPO_ROOT = Path(__file__).parent.parent
+
+
+class TestCLIExitCodes:
+    """CLI must return correct exit codes for CI gating."""
+
+    def test_lint_clean_fixture_exits_0(self):
+        result = subprocess.run(
+            ["uv", "run", "setup-eval", "lint", str(FIXTURES / "sample-setup-a")],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0
+
+    def test_lint_fail_on_error_exits_1_on_errors(self):
+        result = subprocess.run(
+            [
+                "uv",
+                "run",
+                "setup-eval",
+                "lint",
+                str(FIXTURES / "security-issues"),
+                "--fail-on-error",
+            ],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 1
+
+    def test_lint_fail_on_warning_exits_1_on_warnings(self):
+        result = subprocess.run(
+            [
+                "uv",
+                "run",
+                "setup-eval",
+                "lint",
+                str(FIXTURES / "security-issues"),
+                "--fail-on-warning",
+            ],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 1
+
+    def test_lint_json_output_is_valid(self):
+        import json
+
+        result = subprocess.run(
+            [
+                "uv",
+                "run",
+                "setup-eval",
+                "lint",
+                str(FIXTURES / "sample-setup-a"),
+                "--format",
+                "json",
+            ],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0
+        parsed = json.loads(result.stdout)
+        assert "inspection" in parsed
+
+    def test_lint_sarif_output_is_valid(self):
+        import json
+
+        result = subprocess.run(
+            [
+                "uv",
+                "run",
+                "setup-eval",
+                "lint",
+                str(FIXTURES / "sample-setup-a"),
+                "--format",
+                "sarif",
+            ],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0
+        parsed = json.loads(result.stdout)
+        assert parsed.get("version") == "2.1.0"
+
+
+class TestDataFileLoading:
+    """Data files must load correctly and contain expected content."""
+
+    def test_builtins_loads(self):
+        from setup_eval.data import load_builtins
+
+        builtins = load_builtins()
+        assert isinstance(builtins, set)
+        assert len(builtins) >= 10
+        assert "help" in builtins
+        assert "config" in builtins
+
+    def test_tautological_patterns_loads(self):
+        from setup_eval.data import load_tautological_patterns
+
+        patterns = load_tautological_patterns()
+        assert isinstance(patterns, list)
+        assert len(patterns) == 24
+
+    def test_generic_advice_subset(self):
+        from setup_eval.data import load_tautological_patterns
+
+        generic = load_tautological_patterns(generic_advice_only=True)
+        assert len(generic) == 12
+        labels = [label for label, _ in generic]
+        assert "write clean code" in labels
+        assert "be thorough" in labels
+
+    def test_generic_is_subset_of_all(self):
+        from setup_eval.data import load_tautological_patterns
+
+        all_patterns = load_tautological_patterns()
+        generic = load_tautological_patterns(generic_advice_only=True)
+        all_labels = {label for label, _ in all_patterns}
+        for label, _ in generic:
+            assert label in all_labels
+
+    def test_builtins_json_is_valid(self):
+        import json
+
+        path = Path(__file__).parent.parent / "src" / "setup_eval" / "data" / "builtins.json"
+        data = json.loads(path.read_text())
+        assert "claude_code_commands" in data
+        assert isinstance(data["claude_code_commands"], list)
+
+    def test_patterns_json_is_valid(self):
+        import json
+
+        path = (
+            Path(__file__).parent.parent
+            / "src"
+            / "setup_eval"
+            / "data"
+            / "tautological_patterns.json"
+        )
+        data = json.loads(path.read_text())
+        assert "patterns" in data
+        for p in data["patterns"]:
+            assert "label" in p
+            assert "regex" in p
+
+
+class TestTiktokenFallbackIntegration:
+    """The full CLI must work when tiktoken is not available."""
+
+    def test_lint_works_without_tiktoken(self):
+        tokens._reset()
+        with patch.object(
+            tokens, "_init_encoder", side_effect=lambda: setattr(tokens, "_FALLBACK", True)
+        ):
+            tokens._init_encoder()
+        result = subprocess.run(
+            ["uv", "run", "setup-eval", "lint", str(FIXTURES / "sample-setup-a")],
+            capture_output=True,
+            text=True,
+            env={**__import__("os").environ, "TIKTOKEN_CACHE_DIR": "/nonexistent"},
+        )
+        tokens._reset()
+        assert result.returncode == 0
+
+
+class TestSelfDogfood:
+    """setup-eval must be able to lint its own repo without crashing."""
+
+    def test_lint_own_repo_runs(self):
+        result = subprocess.run(
+            ["uv", "run", "setup-eval", "lint", str(REPO_ROOT)],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, f"Dogfood crashed:\n{result.stderr}"
+        assert "Setup Assessment" in result.stdout
+
+    def test_lint_own_repo_json_output(self):
+        import json
+
+        result = subprocess.run(
+            ["uv", "run", "setup-eval", "lint", str(REPO_ROOT), "--format", "json"],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0
+        data = json.loads(result.stdout)
+        assert "inspection" in data
+        assert data["inspection"]["summary"]["total"] > 0

--- a/tests/test_multi_assistant_discovery.py
+++ b/tests/test_multi_assistant_discovery.py
@@ -61,7 +61,8 @@ class TestOpenCodeDiscovery:
     def test_discovers_opencode_instructions(self, opencode_setup_path):
         setup = discover_setup("test", opencode_setup_path)
         claude_mds = setup.by_type(ComponentType.CLAUDE_MD)
-        assert any(c.source_tool == "opencode" for c in claude_mds)
+        # AGENTS.md is a cross-tool standard, attributed as "agents-md"
+        assert any(c.source_tool == "agents-md" for c in claude_mds)
 
     def test_discovers_opencode_commands(self, opencode_setup_path):
         setup = discover_setup("test", opencode_setup_path)


### PR DESCRIPTION
## Summary

Prepares setup-eval for CI pipeline adoption via a future GitHub Action. Addresses issues identified during external review.

### 1. AGENTS.md attribution fixed (cross-tool standard)

AGENTS.md is read by Codex CLI, Copilot CLI, Gemini CLI, Claude Code, and OpenCode. Previously labeled `source_tool="opencode"`, now `source_tool="agents-md"`. OpenCode-specific components (`.opencode/` commands and agents) remain labeled "opencode".

### 2. tiktoken made optional

Moved from hard dependency to optional extra: `pip install setup-eval[tiktoken]`. In air-gapped CI runners, `pip install setup-eval` no longer fails trying to download tiktoken. Token counting falls back to chars/4 heuristic (PR #21).

### 3. Hardcoded knowledge extracted to data files

Created `src/setup_eval/data/` with versioned JSON files:
- `builtins.json`: 16 Claude Code built-in slash commands (used by `command/shadows-builtin` rule)
- `tautological_patterns.json`: 24 patterns for instructions that restate model defaults (used by `claude-md/generic-advice` and `quality/imprecise-instruction` rules)

Eliminates duplication between `generic_advice.py` and `quality/_patterns.py` (identical first 12 patterns). Knowledge that decays with tool updates is now editable without code changes.

### 4. --fail-on-warning flag

New flag for `lint` and `security` commands. Exits with code 1 when any warnings or errors are found (not just errors). Allows stricter CI gating for teams that want zero warnings.

### 5. Version bump

4.0.1 to 4.1.0. Plugin and marketplace versions updated.

## Test plan

- [x] `uv run pytest tests/ -q` passes (408 tests)
- [x] `uv run ruff check src/ tests/` clean
- [x] `uv run ruff format --check src/ tests/` clean
- [x] Data files load correctly at runtime (16 builtins, 24 patterns)
- [x] JSON files are valid
- [ ] `setup-eval lint . --fail-on-warning` exits 1 on warnings
- [ ] `pip install setup-eval` works without tiktoken installed