### PR TITLE
feat: add GitHub Action for CI integration

### DIFF
--- a/.github/actions/setup-eval/action.yml
+++ b/.github/actions/setup-eval/action.yml
@@ -1,0 +1,114 @@
+name: "setup-eval"
+description: "Lint and security-scan AI agent setups (CLAUDE.md, skills, commands, hooks, MCP configs, agents). 58 deterministic rules, no LLM required."
+author: "redhat-community-ai-tools"
+
+branding:
+  icon: "shield"
+  color: "blue"
+
+inputs:
+  path:
+    description: "Directories to scan, one per line. Default scans the repo root."
+    default: "."
+  preset:
+    description: "Rule preset: recommended, strict, security, or pre-workflow"
+    default: "recommended"
+  security-gate:
+    description: "Run security scan (--fail-on-warning). Set to 'false' to skip."
+    default: "true"
+  lint-gate:
+    description: "Run lint scan (--fail-on-error). Set to 'false' to skip."
+    default: "true"
+  lint-fail-on:
+    description: "Lint failure threshold: 'error' (default) or 'warning' (strict)"
+    default: "error"
+  sarif:
+    description: "Upload SARIF to GitHub Code Scanning for inline PR annotations"
+    default: "true"
+  version:
+    description: "setup-eval version to install (e.g. '4.1.0'). Leave empty for latest."
+    default: ""
+
+outputs:
+  security-passed:
+    description: "Whether the security gate passed"
+    value: ${{ steps.security.outcome == 'success' || inputs.security-gate != 'true' }}
+  lint-passed:
+    description: "Whether the lint gate passed"
+    value: ${{ steps.lint.outcome == 'success' || inputs.lint-gate != 'true' }}
+  sarif-file:
+    description: "Path to the SARIF output directory (if generated)"
+    value: ${{ steps.sarif.outputs.sarif-dir }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install setup-eval
+      shell: bash
+      run: |
+        if [ -n "${{ inputs.version }}" ]; then
+          pip install -q "setup-eval==${{ inputs.version }}"
+        else
+          pip install -q setup-eval
+        fi
+
+    - name: Security gate
+      id: security
+      if: inputs.security-gate == 'true'
+      shell: bash
+      run: |
+        failed=0
+        while IFS= read -r dir; do
+          dir=$(echo "$dir" | xargs)
+          [ -z "$dir" ] && continue
+          echo "::group::Security: $dir"
+          if ! setup-eval security "$dir" --fail-on-warning; then
+            failed=1
+          fi
+          echo "::endgroup::"
+        done <<< "${{ inputs.path }}"
+        exit $failed
+
+    - name: Lint gate
+      id: lint
+      if: inputs.lint-gate == 'true'
+      shell: bash
+      run: |
+        fail_flag="--fail-on-error"
+        if [ "${{ inputs.lint-fail-on }}" = "warning" ]; then
+          fail_flag="--fail-on-warning"
+        fi
+        failed=0
+        while IFS= read -r dir; do
+          dir=$(echo "$dir" | xargs)
+          [ -z "$dir" ] && continue
+          echo "::group::Lint: $dir"
+          if ! setup-eval lint "$dir" --preset "${{ inputs.preset }}" $fail_flag; then
+            failed=1
+          fi
+          echo "::endgroup::"
+        done <<< "${{ inputs.path }}"
+        exit $failed
+
+    - name: Generate SARIF
+      id: sarif
+      if: inputs.sarif == 'true' && always()
+      shell: bash
+      run: |
+        sarif_dir="${{ runner.temp }}/setup-eval-sarif"
+        mkdir -p "$sarif_dir"
+        i=0
+        while IFS= read -r dir; do
+          dir=$(echo "$dir" | xargs)
+          [ -z "$dir" ] && continue
+          setup-eval lint "$dir" --preset "${{ inputs.preset }}" --format sarif --output "$sarif_dir/results-$i.sarif" || true
+          i=$((i + 1))
+        done <<< "${{ inputs.path }}"
+        echo "sarif-dir=$sarif_dir" >> "$GITHUB_OUTPUT"
+
+    - name: Upload SARIF
+      if: inputs.sarif == 'true' && always() && steps.sarif.outputs.sarif-dir != ''
+      uses: github/codeql-action/upload-sarif@v3
+      with:
+        sarif_file: ${{ steps.sarif.outputs.sarif-dir }}
+        category: setup-eval

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- GitHub Action at `.github/actions/setup-eval/`: one-step CI integration with two-tier gating (security + lint) and SARIF upload for inline PR annotations
 - 22 new tests covering all 16 previously untested rules (agent, command, and content categories)
 
 ## [4.1.0] - 2026-07-08

--- a/README.md
+++ b/README.md
@@ -64,20 +64,65 @@ Requires `GEMINI_API_KEY` or `ANTHROPIC_API_KEY` for review/security/skill comma
 
 `setup-eval security` supports optional YARA malware signature scanning. To enable it: `pip install setup-eval[yara]`
 
-### CI integration
+### GitHub Action
 
-Two-tier gating recommended: security blocks on any finding (including warnings), lint blocks only on structural errors.
+Runs two-tier gating (security + lint) and posts inline PR annotations via GitHub Code Scanning. No API key needed, no LLM calls, fully deterministic.
+
+**Quick start:** Create `.github/workflows/setup-eval.yml` in your repo:
 
 ```yaml
-# GitHub Actions example
+name: Agent Setup Check
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  security-events: write    # required for SARIF upload
+  contents: read
+
+jobs:
+  setup-eval:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: redhat-community-ai-tools/setup-eval/.github/actions/setup-eval@main
+```
+
+That's it. Every PR now gets security + lint checks with inline annotations on the diff.
+
+**Options:**
+
+```yaml
+      - uses: redhat-community-ai-tools/setup-eval/.github/actions/setup-eval@main
+        with:
+          path: "."              # directories to scan, one per line (default: repo root)
+          preset: "recommended"  # recommended, strict, security, or pre-workflow
+          security-gate: "true"  # block on any security finding
+          lint-gate: "true"      # block on structural errors
+          lint-fail-on: "error"  # "error" (default) or "warning" (strict)
+          sarif: "true"          # inline PR annotations via Code Scanning
+          version: ""            # pin a specific version (default: latest)
+```
+
+**Multiple directories** (monorepos or repos with nested agent configs):
+
+```yaml
+      - uses: redhat-community-ai-tools/setup-eval/.github/actions/setup-eval@main
+        with:
+          path: |
+            .
+            internal/scaffold/agent-configs
+            apps/frontend
+```
+
+### Manual CI integration
+
+If you prefer manual setup over the action:
+
+```yaml
 - run: pip install setup-eval
 - run: setup-eval security . --fail-on-warning   # strict: any security finding blocks
 - run: setup-eval lint . --fail-on-error          # lenient: only errors block
-```
-
-For SARIF output (inline PR annotations via GitHub Code Scanning):
-
-```yaml
 - run: setup-eval lint . --format sarif --output results.sarif
 - uses: github/codeql-action/upload-sarif@v3
   with:


### PR DESCRIPTION
## Summary

Adds a reusable GitHub Action at `.github/actions/setup-eval/` for one-step CI integration.

### Usage

```yaml
- uses: redhat-community-ai-tools/setup-eval/.github/actions/setup-eval@v4
```

### What it does

1. Installs setup-eval from PyPI
2. Runs security gate (`--fail-on-warning`): blocks on any security finding
3. Runs lint gate (`--fail-on-error`): blocks on structural errors only
4. Generates SARIF and uploads to GitHub Code Scanning for inline PR annotations

No LLM, no API key, fully deterministic.

### Configurable inputs

| Input | Default | Description |
|---|---|---|
| `path` | `.` | Directory to scan |
| `preset` | `recommended` | Rule preset |
| `security-gate` | `true` | Run security scan |
| `lint-gate` | `true` | Run lint scan |
| `lint-fail-on` | `error` | `error` or `warning` for lint |
| `sarif` | `true` | Upload SARIF for inline annotations |
| `version` | latest | Pin a specific setup-eval version |

### Files changed

- `.github/actions/setup-eval/action.yml` (new, composite action)
- `README.md` (GitHub Action usage section added)
- `CHANGELOG.md` (entry under Unreleased)

## Checklist

- [x] `uv run pytest tests/ -q` passes (444 tests)
- [x] `uv run ruff check src/ tests/` clean
- [x] `uv run ruff format --check src/ tests/` clean
- [x] `uv run setup-eval security . --fail-on-warning` clean
- [x] `uv run setup-eval lint . --fail-on-error` clean