### PR TITLE
feat: add --recursive flag for deep agent config discovery

### DIFF
--- a/.github/actions/harness-eval/action.yml
+++ b/.github/actions/harness-eval/action.yml
@@ -28,6 +28,9 @@ inputs:
   comment:
     description: "Post a summary comment on pull requests"
     default: "true"
+  recursive:
+    description: "Recursively search for agent configs in all subdirectories"
+    default: "false"
   version:
     description: "harness-eval version to install (e.g. '5.0.0'). Leave empty for latest."
     default: ""
@@ -62,12 +65,16 @@ runs:
       shell: bash
       run: |
         echo "=== Security Scan ==="
+        recursive_flag=""
+        if [ "${{ inputs.recursive }}" = "true" ]; then
+          recursive_flag="--recursive"
+        fi
         failed=0
         while IFS= read -r dir; do
           dir=$(echo "$dir" | xargs)
           [ -z "$dir" ] && continue
-          harness-eval security "$dir" || true
-          if ! harness-eval security "$dir" --fail-on-warning > /dev/null 2>&1; then
+          harness-eval security "$dir" $recursive_flag || true
+          if ! harness-eval security "$dir" $recursive_flag --fail-on-warning > /dev/null 2>&1; then
             failed=1
           fi
         done <<< "${{ inputs.path }}"
@@ -83,6 +90,10 @@ runs:
         if [ "${{ inputs.lint-fail-on }}" = "warning" ]; then
           fail_flag="--fail-on-warning"
         fi
+        recursive_flag=""
+        if [ "${{ inputs.recursive }}" = "true" ]; then
+          recursive_flag="--recursive"
+        fi
         failed=0
         json_dir="${{ runner.temp }}/harness-eval-json"
         mkdir -p "$json_dir"
@@ -90,9 +101,9 @@ runs:
         while IFS= read -r dir; do
           dir=$(echo "$dir" | xargs)
           [ -z "$dir" ] && continue
-          harness-eval lint "$dir" --preset "${{ inputs.preset }}" || true
-          harness-eval lint "$dir" --preset "${{ inputs.preset }}" --format json > "$json_dir/lint-$i.json" 2>/dev/null || true
-          if ! harness-eval lint "$dir" --preset "${{ inputs.preset }}" $fail_flag > /dev/null 2>&1; then
+          harness-eval lint "$dir" --preset "${{ inputs.preset }}" $recursive_flag || true
+          harness-eval lint "$dir" --preset "${{ inputs.preset }}" $recursive_flag --format json > "$json_dir/lint-$i.json" 2>/dev/null || true
+          if ! harness-eval lint "$dir" --preset "${{ inputs.preset }}" $recursive_flag $fail_flag > /dev/null 2>&1; then
             failed=1
           fi
           i=$((i + 1))
@@ -107,12 +118,16 @@ runs:
       run: |
         sarif_dir="${{ runner.temp }}/harness-eval-sarif"
         mkdir -p "$sarif_dir"
+        recursive_flag=""
+        if [ "${{ inputs.recursive }}" = "true" ]; then
+          recursive_flag="--recursive"
+        fi
         total_results=0
         i=0
         while IFS= read -r dir; do
           dir=$(echo "$dir" | xargs)
           [ -z "$dir" ] && continue
-          harness-eval lint "$dir" --preset "${{ inputs.preset }}" --format sarif --output "$sarif_dir/results-$i.sarif" || true
+          harness-eval lint "$dir" --preset "${{ inputs.preset }}" $recursive_flag --format sarif --output "$sarif_dir/results-$i.sarif" || true
           count=$(python3 -c "import json; d=json.load(open('$sarif_dir/results-$i.sarif')); print(len(d['runs'][0]['results']))" 2>/dev/null || echo "0")
           total_results=$((total_results + count))
           i=$((i + 1))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- `--recursive` flag for lint and security: search the entire directory tree for agent configs in nested directories (skills, agents, commands, hooks, MCP configs)
+- Recursive mode in GitHub Action via `recursive: "true"` input
+
 ## [5.1.0] - 2026-07-20
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ All notable changes to this project will be documented in this file.
 - `--recursive` flag for lint and security: search the entire directory tree for agent configs in nested directories (skills, agents, commands, hooks, MCP configs)
 - Recursive mode in GitHub Action via `recursive: "true"` input
 
+### Fixed
+- `--recursive` now skips symlinks that resolve outside the project boundary, preventing traversal into unrelated directories
+
 ## [5.1.0] - 2026-07-20
 
 ### Added

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -90,6 +90,27 @@ For monorepos or repos with nested agent configs:
             apps/frontend
 ```
 
+### Recursive discovery
+
+By default, harness-eval scans the repo root for agent config files (CLAUDE.md, skills, commands, hooks, MCP configs, agents). Use `--recursive` to search the entire directory tree for agent configs in nested directories. This is useful for monorepos and repos with scaffold templates.
+
+CLI:
+
+```bash
+harness-eval lint . --recursive
+harness-eval security . --recursive
+```
+
+GitHub Action:
+
+```yaml
+      - uses: redhat-community-ai-tools/harness-eval/.github/actions/harness-eval@main
+        with:
+          recursive: "true"
+```
+
+Directories like `.git/`, `__pycache__/`, `node_modules/`, `.venv/`, `vendor/`, and `.tox/` are automatically excluded from the recursive search.
+
 ### What appears on the PR
 
 The action posts a comment showing:

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -111,6 +111,8 @@ GitHub Action:
 
 Directories like `.git/`, `__pycache__/`, `node_modules/`, `.venv/`, `vendor/`, and `.tox/` are automatically excluded from the recursive search.
 
+Note: `--recursive` follows symlinks within the project directory but skips symlinks that point outside the project boundary.
+
 ### What appears on the PR
 
 The action posts a comment showing:

--- a/src/harness_eval/cli/lint.py
+++ b/src/harness_eval/cli/lint.py
@@ -53,6 +53,11 @@ from harness_eval.output.metadata import EvalMetadata
     default=None,
     help="Path to ~/.claude directory for user-level CLAUDE.md discovery.",
 )
+@click.option(
+    "--recursive",
+    is_flag=True,
+    help="Recursively search for agent configs in all subdirectories.",
+)
 def eval_setup_lint(
     path: str,
     preset: str,
@@ -63,6 +68,7 @@ def eval_setup_lint(
     watch: bool,
     fail_on_warning: bool,
     user_config: str | None,
+    recursive: bool,
 ) -> None:
     """Lint: 64 rules + system analysis. No LLM, deterministic, fast."""
     if watch:
@@ -88,7 +94,9 @@ def eval_setup_lint(
     target = Path(path)
 
     if target.is_dir():
-        setup = discover_setup(name=target.name, path=path, user_config_dir=user_config)
+        setup = discover_setup(
+            name=target.name, path=path, user_config_dir=user_config, recursive=recursive
+        )
         results = inspect_setup(setup, config_rules)
         system = analyze_system(setup)
 

--- a/src/harness_eval/cli/security.py
+++ b/src/harness_eval/cli/security.py
@@ -99,6 +99,11 @@ def _parse_adjudication_response(
     default=None,
     help="Path to ~/.claude directory for user-level CLAUDE.md discovery.",
 )
+@click.option(
+    "--recursive",
+    is_flag=True,
+    help="Recursively search for agent configs in all subdirectories.",
+)
 def eval_setup_security(
     path: str,
     fmt: str,
@@ -109,6 +114,7 @@ def eval_setup_security(
     fail_on_error: bool,
     fail_on_warning: bool,
     user_config: str | None,
+    recursive: bool,
 ) -> None:
     """Deep security audit: all deterministic security rules + optional LLM review."""
     t0 = time.monotonic()
@@ -116,7 +122,9 @@ def eval_setup_security(
     from harness_eval.inspection.engine import inspect_setup
 
     target = Path(path)
-    setup = discover_setup(name=target.name, path=path, user_config_dir=user_config)
+    setup = discover_setup(
+        name=target.name, path=path, user_config_dir=user_config, recursive=recursive
+    )
     results = inspect_setup(setup, SECURITY)
 
     skip_rules = {"security/yara-signatures", "security/cve-lookup"}

--- a/src/harness_eval/core/discoverers/base.py
+++ b/src/harness_eval/core/discoverers/base.py
@@ -13,6 +13,19 @@ from harness_eval.core.types import (
 from harness_eval.utils.parsing import parse_frontmatter
 from harness_eval.utils.tokens import count_tokens
 
+_EXCLUDE_DIRS = {".git", "__pycache__", "node_modules", ".venv", "vendor", ".tox"}
+
+
+def _recursive_glob(root: Path, pattern: str) -> list[Path]:
+    """Glob recursively, excluding common non-project directories."""
+    results = []
+    for f in sorted(root.rglob(pattern)):
+        if any(excluded in f.parts for excluded in _EXCLUDE_DIRS):
+            continue
+        if f.is_file():
+            results.append(f)
+    return results
+
 
 def parse_file(
     filepath: Path,
@@ -54,9 +67,13 @@ class ToolDiscoverer(ABC):
         """Return True if this tool's setup files exist in root."""
 
     @abstractmethod
-    def discover(self, root: Path, user_config_dir: Path | None = None) -> list[ParsedComponent]:
+    def discover(
+        self, root: Path, user_config_dir: Path | None = None, *, recursive: bool = False
+    ) -> list[ParsedComponent]:
         """Discover all components for this tool."""
 
     @abstractmethod
-    def collect_paths(self, root: Path, user_config_dir: Path | None = None) -> list[Path]:
+    def collect_paths(
+        self, root: Path, user_config_dir: Path | None = None, *, recursive: bool = False
+    ) -> list[Path]:
         """Return file paths this discoverer would scan (for watch mode)."""

--- a/src/harness_eval/core/discoverers/base.py
+++ b/src/harness_eval/core/discoverers/base.py
@@ -17,13 +17,26 @@ _EXCLUDE_DIRS = {".git", "__pycache__", "node_modules", ".venv", "vendor", ".tox
 
 
 def _recursive_glob(root: Path, pattern: str) -> list[Path]:
-    """Glob recursively, excluding common non-project directories."""
+    """Glob recursively, excluding common non-project directories.
+
+    Skips symlinks that resolve outside the repo root to prevent
+    traversal into unrelated directories.
+    """
+    resolved_root = root.resolve()
     results = []
     for f in sorted(root.rglob(pattern)):
         if any(excluded in f.parts for excluded in _EXCLUDE_DIRS):
             continue
-        if f.is_file():
-            results.append(f)
+        if not f.is_file():
+            continue
+        if f.is_symlink():
+            try:
+                if not f.resolve().is_relative_to(resolved_root):
+                    continue
+            except (OSError, ValueError):
+                # Unresolvable symlink (broken, permissions, etc.)
+                continue
+        results.append(f)
     return results
 
 

--- a/src/harness_eval/core/discoverers/claude.py
+++ b/src/harness_eval/core/discoverers/claude.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from harness_eval.core.discoverers.base import ToolDiscoverer, parse_file
+from harness_eval.core.discoverers.base import ToolDiscoverer, _recursive_glob, parse_file
 from harness_eval.core.types import (
     ComponentScope,
     ComponentType,
@@ -26,19 +26,23 @@ class ClaudeCodeDiscoverer(ToolDiscoverer):
     def detect(self, root: Path) -> bool:
         return (root / "CLAUDE.md").is_file() or (root / ".claude").is_dir()
 
-    def discover(self, root: Path, user_config_dir: Path | None = None) -> list[ParsedComponent]:
+    def discover(
+        self, root: Path, user_config_dir: Path | None = None, *, recursive: bool = False
+    ) -> list[ParsedComponent]:
         results: list[ParsedComponent] = []
         results.extend(self._discover_claude_md(root, user_config_dir))
-        results.extend(self._discover_skills(root))
-        results.extend(self._discover_commands(root))
-        results.extend(self._discover_hooks(root))
-        results.extend(self._discover_agents(root))
+        results.extend(self._discover_skills(root, recursive=recursive))
+        results.extend(self._discover_commands(root, recursive=recursive))
+        results.extend(self._discover_hooks(root, recursive=recursive))
+        results.extend(self._discover_agents(root, recursive=recursive))
         results.extend(self._discover_mcp_configs(root))
         results.extend(self._discover_rules(root))
         results.extend(self._discover_output_styles(root))
         return results
 
-    def collect_paths(self, root: Path, user_config_dir: Path | None = None) -> list[Path]:
+    def collect_paths(
+        self, root: Path, user_config_dir: Path | None = None, *, recursive: bool = False
+    ) -> list[Path]:
         paths: list[Path] = []
 
         # CLAUDE.md - project-local
@@ -65,6 +69,9 @@ class ClaudeCodeDiscoverer(ToolDiscoverer):
             if skills_dir.is_dir():
                 for f in sorted(skills_dir.rglob("SKILL.md")):
                     paths.append(f)
+        if recursive:
+            for f in _recursive_glob(root, "skills/*/SKILL.md"):
+                paths.append(f)
 
         # Commands
         for commands_dir in [root / "commands", root / ".claude" / "commands"]:
@@ -76,11 +83,21 @@ class ClaudeCodeDiscoverer(ToolDiscoverer):
                         cmd_md = item / "command.md"
                         if cmd_md.is_file():
                             paths.append(cmd_md)
+        if recursive:
+            for f in _recursive_glob(root, "commands/*.md"):
+                paths.append(f)
+            for f in _recursive_glob(root, "commands/*/command.md"):
+                paths.append(f)
 
         # Settings / hooks
         settings = root / ".claude" / "settings.json"
         if settings.is_file():
             paths.append(settings)
+        if recursive:
+            for f in _recursive_glob(root, ".claude/settings.json"):
+                paths.append(f)
+            for f in _recursive_glob(root, "settings.json"):
+                paths.append(f)
 
         # Agents
         agents_dir = root / ".claude" / "agents"
@@ -88,6 +105,9 @@ class ClaudeCodeDiscoverer(ToolDiscoverer):
             for f in sorted(agents_dir.glob("*.md")):
                 if f.is_file():
                     paths.append(f)
+        if recursive:
+            for f in _recursive_glob(root, ".claude/agents/*.md"):
+                paths.append(f)
 
         # MCP configs
         for pattern in [".mcp.json", "**/.mcp.json"]:
@@ -170,7 +190,7 @@ class ClaudeCodeDiscoverer(ToolDiscoverer):
 
         return results
 
-    def _discover_skills(self, root: Path) -> list[ParsedComponent]:
+    def _discover_skills(self, root: Path, *, recursive: bool = False) -> list[ParsedComponent]:
         results = []
         seen_paths: set[str] = set()
         for skills_dir in [root / "skills", root / ".claude" / "skills"]:
@@ -186,45 +206,101 @@ class ClaudeCodeDiscoverer(ToolDiscoverer):
                 results.append(
                     parse_file(skill_md, ComponentType.SKILL, name=skill_dir.name, source_tool=tool)
                 )
+        if recursive:
+            for skill_md in _recursive_glob(root, "skills/*/SKILL.md"):
+                resolved = str(skill_md.resolve())
+                if resolved in seen_paths:
+                    continue
+                seen_paths.add(resolved)
+                results.append(
+                    parse_file(
+                        skill_md, ComponentType.SKILL, name=skill_md.parent.name, source_tool=None
+                    )
+                )
         return results
 
-    def _discover_commands(self, root: Path) -> list[ParsedComponent]:
+    def _discover_commands(self, root: Path, *, recursive: bool = False) -> list[ParsedComponent]:
         results = []
+        seen_paths: set[str] = set()
         for commands_dir in [root / "commands", root / ".claude" / "commands"]:
             if not commands_dir.is_dir():
                 continue
             tool = "claude" if ".claude" in commands_dir.parts else None
             for item in sorted(commands_dir.iterdir()):
                 if item.is_file() and item.suffix == ".md":
+                    seen_paths.add(str(item.resolve()))
                     results.append(parse_file(item, ComponentType.COMMAND, source_tool=tool))
                 elif item.is_dir():
                     cmd_md = item / "command.md"
                     if cmd_md.is_file():
+                        seen_paths.add(str(cmd_md.resolve()))
                         results.append(
                             parse_file(
                                 cmd_md, ComponentType.COMMAND, name=item.name, source_tool=tool
                             )
                         )
+        if recursive:
+            for f in _recursive_glob(root, "commands/*.md"):
+                resolved = str(f.resolve())
+                if resolved not in seen_paths:
+                    seen_paths.add(resolved)
+                    results.append(parse_file(f, ComponentType.COMMAND, source_tool=None))
+            for f in _recursive_glob(root, "commands/*/command.md"):
+                resolved = str(f.resolve())
+                if resolved not in seen_paths:
+                    seen_paths.add(resolved)
+                    results.append(
+                        parse_file(f, ComponentType.COMMAND, name=f.parent.name, source_tool=None)
+                    )
         return results
 
-    def _discover_hooks(self, root: Path) -> list[ParsedComponent]:
+    def _discover_hooks(self, root: Path, *, recursive: bool = False) -> list[ParsedComponent]:
+        results = []
+        seen_paths: set[str] = set()
         settings = root / ".claude" / "settings.json"
         if settings.is_file():
-            return [
+            seen_paths.add(str(settings.resolve()))
+            results.append(
                 parse_file(
                     settings, ComponentType.HOOKS, name="settings.json", source_tool="claude"
                 )
-            ]
-        return []
+            )
+        if recursive:
+            for f in _recursive_glob(root, ".claude/settings.json"):
+                resolved = str(f.resolve())
+                if resolved not in seen_paths:
+                    seen_paths.add(resolved)
+                    results.append(
+                        parse_file(
+                            f, ComponentType.HOOKS, name="settings.json", source_tool="claude"
+                        )
+                    )
+            for f in _recursive_glob(root, "settings.json"):
+                resolved = str(f.resolve())
+                if resolved not in seen_paths:
+                    seen_paths.add(resolved)
+                    results.append(
+                        parse_file(
+                            f, ComponentType.HOOKS, name="settings.json", source_tool="claude"
+                        )
+                    )
+        return results
 
-    def _discover_agents(self, root: Path) -> list[ParsedComponent]:
+    def _discover_agents(self, root: Path, *, recursive: bool = False) -> list[ParsedComponent]:
         results = []
+        seen_paths: set[str] = set()
         agents_dir = root / ".claude" / "agents"
-        if not agents_dir.is_dir():
-            return results
-        for f in sorted(agents_dir.glob("*.md")):
-            if f.is_file():
-                results.append(parse_file(f, ComponentType.AGENT, source_tool="claude"))
+        if agents_dir.is_dir():
+            for f in sorted(agents_dir.glob("*.md")):
+                if f.is_file():
+                    seen_paths.add(str(f.resolve()))
+                    results.append(parse_file(f, ComponentType.AGENT, source_tool="claude"))
+        if recursive:
+            for f in _recursive_glob(root, ".claude/agents/*.md"):
+                resolved = str(f.resolve())
+                if resolved not in seen_paths:
+                    seen_paths.add(resolved)
+                    results.append(parse_file(f, ComponentType.AGENT, source_tool="claude"))
         return results
 
     def _discover_mcp_configs(self, root: Path) -> list[ParsedComponent]:

--- a/src/harness_eval/core/discoverers/copilot.py
+++ b/src/harness_eval/core/discoverers/copilot.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from harness_eval.core.discoverers.base import ToolDiscoverer, parse_file
+from harness_eval.core.discoverers.base import ToolDiscoverer, _recursive_glob, parse_file
 from harness_eval.core.types import ComponentType, ParsedComponent
 
 
@@ -26,20 +26,27 @@ class CopilotDiscoverer(ToolDiscoverer):
             or (root / ".github" / "skills").is_dir()
         )
 
-    def discover(self, root: Path, user_config_dir: Path | None = None) -> list[ParsedComponent]:
+    def discover(
+        self, root: Path, user_config_dir: Path | None = None, *, recursive: bool = False
+    ) -> list[ParsedComponent]:
         results: list[ParsedComponent] = []
-        results.extend(self._discover_skills(root))
-        results.extend(self._discover_commands(root))
-        results.extend(self._discover_agents(root))
+        results.extend(self._discover_skills(root, recursive=recursive))
+        results.extend(self._discover_commands(root, recursive=recursive))
+        results.extend(self._discover_agents(root, recursive=recursive))
         return results
 
-    def collect_paths(self, root: Path, user_config_dir: Path | None = None) -> list[Path]:
+    def collect_paths(
+        self, root: Path, user_config_dir: Path | None = None, *, recursive: bool = False
+    ) -> list[Path]:
         paths: list[Path] = []
 
         # Copilot skills
         copilot_skills = root / ".github" / "skills"
         if copilot_skills.is_dir():
             for f in sorted(copilot_skills.rglob("SKILL.md")):
+                paths.append(f)
+        if recursive:
+            for f in _recursive_glob(root, ".github/skills/*/SKILL.md"):
                 paths.append(f)
 
         # Copilot commands (prompts)
@@ -48,6 +55,9 @@ class CopilotDiscoverer(ToolDiscoverer):
             for f in sorted(copilot_commands.iterdir()):
                 if f.is_file() and f.suffix == ".md":
                     paths.append(f)
+        if recursive:
+            for f in _recursive_glob(root, ".github/prompts/*.md"):
+                paths.append(f)
 
         # Copilot agents
         copilot_agents = root / ".github" / "agents"
@@ -55,43 +65,76 @@ class CopilotDiscoverer(ToolDiscoverer):
             for f in sorted(copilot_agents.glob("*.md")):
                 if f.is_file():
                     paths.append(f)
+        if recursive:
+            for f in _recursive_glob(root, ".github/agents/*.md"):
+                paths.append(f)
 
         return paths
 
-    def _discover_skills(self, root: Path) -> list[ParsedComponent]:
+    def _discover_skills(self, root: Path, *, recursive: bool = False) -> list[ParsedComponent]:
         results = []
+        seen_paths: set[str] = set()
         skills_dir = root / ".github" / "skills"
-        if not skills_dir.is_dir():
-            return results
-        for skill_md in sorted(skills_dir.rglob("SKILL.md")):
-            results.append(
-                parse_file(
-                    skill_md,
-                    ComponentType.SKILL,
-                    name=skill_md.parent.name,
-                    source_tool="copilot",
-                )
-            )
-        return results
-
-    def _discover_commands(self, root: Path) -> list[ParsedComponent]:
-        results = []
-        commands_dir = root / ".github" / "prompts"
-        if not commands_dir.is_dir():
-            return results
-        for f in sorted(commands_dir.iterdir()):
-            if f.is_file() and f.suffix == ".md":
+        if skills_dir.is_dir():
+            for skill_md in sorted(skills_dir.rglob("SKILL.md")):
+                seen_paths.add(str(skill_md.resolve()))
                 results.append(
-                    parse_file(f, ComponentType.COMMAND, name=f.stem, source_tool="copilot")
+                    parse_file(
+                        skill_md,
+                        ComponentType.SKILL,
+                        name=skill_md.parent.name,
+                        source_tool="copilot",
+                    )
                 )
+        if recursive:
+            for skill_md in _recursive_glob(root, ".github/skills/*/SKILL.md"):
+                resolved = str(skill_md.resolve())
+                if resolved not in seen_paths:
+                    seen_paths.add(resolved)
+                    results.append(
+                        parse_file(
+                            skill_md,
+                            ComponentType.SKILL,
+                            name=skill_md.parent.name,
+                            source_tool="copilot",
+                        )
+                    )
         return results
 
-    def _discover_agents(self, root: Path) -> list[ParsedComponent]:
+    def _discover_commands(self, root: Path, *, recursive: bool = False) -> list[ParsedComponent]:
         results = []
+        seen_paths: set[str] = set()
+        commands_dir = root / ".github" / "prompts"
+        if commands_dir.is_dir():
+            for f in sorted(commands_dir.iterdir()):
+                if f.is_file() and f.suffix == ".md":
+                    seen_paths.add(str(f.resolve()))
+                    results.append(
+                        parse_file(f, ComponentType.COMMAND, name=f.stem, source_tool="copilot")
+                    )
+        if recursive:
+            for f in _recursive_glob(root, ".github/prompts/*.md"):
+                resolved = str(f.resolve())
+                if resolved not in seen_paths:
+                    seen_paths.add(resolved)
+                    results.append(
+                        parse_file(f, ComponentType.COMMAND, name=f.stem, source_tool="copilot")
+                    )
+        return results
+
+    def _discover_agents(self, root: Path, *, recursive: bool = False) -> list[ParsedComponent]:
+        results = []
+        seen_paths: set[str] = set()
         agents_dir = root / ".github" / "agents"
-        if not agents_dir.is_dir():
-            return results
-        for f in sorted(agents_dir.glob("*.md")):
-            if f.is_file():
-                results.append(parse_file(f, ComponentType.AGENT, source_tool="copilot"))
+        if agents_dir.is_dir():
+            for f in sorted(agents_dir.glob("*.md")):
+                if f.is_file():
+                    seen_paths.add(str(f.resolve()))
+                    results.append(parse_file(f, ComponentType.AGENT, source_tool="copilot"))
+        if recursive:
+            for f in _recursive_glob(root, ".github/agents/*.md"):
+                resolved = str(f.resolve())
+                if resolved not in seen_paths:
+                    seen_paths.add(resolved)
+                    results.append(parse_file(f, ComponentType.AGENT, source_tool="copilot"))
         return results

--- a/src/harness_eval/core/discoverers/cursor.py
+++ b/src/harness_eval/core/discoverers/cursor.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from harness_eval.core.discoverers.base import ToolDiscoverer, parse_file
+from harness_eval.core.discoverers.base import ToolDiscoverer, _recursive_glob, parse_file
 from harness_eval.core.types import ComponentType, ParsedComponent
 
 
@@ -22,16 +22,20 @@ class CursorDiscoverer(ToolDiscoverer):
     def detect(self, root: Path) -> bool:
         return (root / ".cursor").is_dir() or (root / ".cursorrules").is_file()
 
-    def discover(self, root: Path, user_config_dir: Path | None = None) -> list[ParsedComponent]:
+    def discover(
+        self, root: Path, user_config_dir: Path | None = None, *, recursive: bool = False
+    ) -> list[ParsedComponent]:
         results: list[ParsedComponent] = []
-        results.extend(self._discover_rules(root))
-        results.extend(self._discover_commands(root))
-        results.extend(self._discover_skills(root))
-        results.extend(self._discover_hooks(root))
-        results.extend(self._discover_mcp(root))
+        results.extend(self._discover_rules(root, recursive=recursive))
+        results.extend(self._discover_commands(root, recursive=recursive))
+        results.extend(self._discover_skills(root, recursive=recursive))
+        results.extend(self._discover_hooks(root, recursive=recursive))
+        results.extend(self._discover_mcp(root, recursive=recursive))
         return results
 
-    def collect_paths(self, root: Path, user_config_dir: Path | None = None) -> list[Path]:
+    def collect_paths(
+        self, root: Path, user_config_dir: Path | None = None, *, recursive: bool = False
+    ) -> list[Path]:
         paths: list[Path] = []
 
         # Cursor rules
@@ -40,9 +44,15 @@ class CursorDiscoverer(ToolDiscoverer):
             for f in sorted(cursor_rules_dir.rglob("*.mdc")):
                 if f.is_file():
                     paths.append(f)
+        if recursive:
+            for f in _recursive_glob(root, ".cursor/rules/*.mdc"):
+                paths.append(f)
 
         for f in sorted(root.rglob(".cursorrules")):
             if f.is_file() and ".git" not in f.parts:
+                paths.append(f)
+        if recursive:
+            for f in _recursive_glob(root, ".cursorrules"):
                 paths.append(f)
 
         # Cursor commands
@@ -51,26 +61,38 @@ class CursorDiscoverer(ToolDiscoverer):
             for f in sorted(cursor_commands.iterdir()):
                 if f.is_file() and f.suffix == ".md":
                     paths.append(f)
+        if recursive:
+            for f in _recursive_glob(root, ".cursor/commands/*.md"):
+                paths.append(f)
 
         # Cursor skills
         cursor_skills = root / ".cursor" / "skills"
         if cursor_skills.is_dir():
             for f in sorted(cursor_skills.rglob("SKILL.md")):
                 paths.append(f)
+        if recursive:
+            for f in _recursive_glob(root, ".cursor/skills/*/SKILL.md"):
+                paths.append(f)
 
         # Cursor hooks
         cursor_hooks = root / ".cursor" / "hooks.json"
         if cursor_hooks.is_file():
             paths.append(cursor_hooks)
+        if recursive:
+            for f in _recursive_glob(root, ".cursor/hooks.json"):
+                paths.append(f)
 
         # Cursor MCP
         cursor_mcp = root / ".cursor" / "mcp.json"
         if cursor_mcp.is_file():
             paths.append(cursor_mcp)
+        if recursive:
+            for f in _recursive_glob(root, ".cursor/mcp.json"):
+                paths.append(f)
 
         return paths
 
-    def _discover_rules(self, root: Path) -> list[ParsedComponent]:
+    def _discover_rules(self, root: Path, *, recursive: bool = False) -> list[ParsedComponent]:
         results: list[ParsedComponent] = []
         seen_paths: set[str] = set()
 
@@ -87,6 +109,15 @@ class CursorDiscoverer(ToolDiscoverer):
                             )
                         )
 
+        if recursive:
+            for f in _recursive_glob(root, ".cursor/rules/*.mdc"):
+                resolved = str(f.resolve())
+                if resolved not in seen_paths:
+                    seen_paths.add(resolved)
+                    results.append(
+                        parse_file(f, ComponentType.CLAUDE_MD, name=f.stem, source_tool="cursor")
+                    )
+
         for f in sorted(root.rglob(".cursorrules")):
             if f.is_file() and ".git" not in f.parts:
                 resolved = str(f.resolve())
@@ -98,57 +129,116 @@ class CursorDiscoverer(ToolDiscoverer):
                         parse_file(f, ComponentType.CLAUDE_MD, name=name, source_tool="cursor")
                     )
 
+        if recursive:
+            for f in _recursive_glob(root, ".cursorrules"):
+                resolved = str(f.resolve())
+                if resolved not in seen_paths:
+                    seen_paths.add(resolved)
+                    rel = f.relative_to(root)
+                    name = str(rel) if rel != Path(".cursorrules") else ".cursorrules"
+                    results.append(
+                        parse_file(f, ComponentType.CLAUDE_MD, name=name, source_tool="cursor")
+                    )
+
         return results
 
-    def _discover_commands(self, root: Path) -> list[ParsedComponent]:
+    def _discover_commands(self, root: Path, *, recursive: bool = False) -> list[ParsedComponent]:
         results = []
+        seen_paths: set[str] = set()
         commands_dir = root / ".cursor" / "commands"
-        if not commands_dir.is_dir():
-            return results
-        for f in sorted(commands_dir.iterdir()):
-            if f.is_file() and f.suffix == ".md":
-                results.append(
-                    parse_file(f, ComponentType.COMMAND, name=f.stem, source_tool="cursor")
-                )
+        if commands_dir.is_dir():
+            for f in sorted(commands_dir.iterdir()):
+                if f.is_file() and f.suffix == ".md":
+                    seen_paths.add(str(f.resolve()))
+                    results.append(
+                        parse_file(f, ComponentType.COMMAND, name=f.stem, source_tool="cursor")
+                    )
+        if recursive:
+            for f in _recursive_glob(root, ".cursor/commands/*.md"):
+                resolved = str(f.resolve())
+                if resolved not in seen_paths:
+                    seen_paths.add(resolved)
+                    results.append(
+                        parse_file(f, ComponentType.COMMAND, name=f.stem, source_tool="cursor")
+                    )
         return results
 
-    def _discover_skills(self, root: Path) -> list[ParsedComponent]:
+    def _discover_skills(self, root: Path, *, recursive: bool = False) -> list[ParsedComponent]:
         results = []
         seen_paths: set[str] = set()
         skills_dir = root / ".cursor" / "skills"
-        if not skills_dir.is_dir():
-            return results
-        for skill_md in sorted(skills_dir.rglob("SKILL.md")):
-            resolved = str(skill_md.resolve())
-            if resolved not in seen_paths:
-                seen_paths.add(resolved)
-                results.append(
-                    parse_file(
-                        skill_md,
-                        ComponentType.SKILL,
-                        name=skill_md.parent.name,
-                        source_tool="cursor",
+        if skills_dir.is_dir():
+            for skill_md in sorted(skills_dir.rglob("SKILL.md")):
+                resolved = str(skill_md.resolve())
+                if resolved not in seen_paths:
+                    seen_paths.add(resolved)
+                    results.append(
+                        parse_file(
+                            skill_md,
+                            ComponentType.SKILL,
+                            name=skill_md.parent.name,
+                            source_tool="cursor",
+                        )
                     )
-                )
+        if recursive:
+            for skill_md in _recursive_glob(root, ".cursor/skills/*/SKILL.md"):
+                resolved = str(skill_md.resolve())
+                if resolved not in seen_paths:
+                    seen_paths.add(resolved)
+                    results.append(
+                        parse_file(
+                            skill_md,
+                            ComponentType.SKILL,
+                            name=skill_md.parent.name,
+                            source_tool="cursor",
+                        )
+                    )
         return results
 
-    def _discover_hooks(self, root: Path) -> list[ParsedComponent]:
+    def _discover_hooks(self, root: Path, *, recursive: bool = False) -> list[ParsedComponent]:
+        results = []
+        seen_paths: set[str] = set()
         hooks_file = root / ".cursor" / "hooks.json"
         if hooks_file.is_file():
-            return [
+            seen_paths.add(str(hooks_file.resolve()))
+            results.append(
                 parse_file(hooks_file, ComponentType.HOOKS, name="hooks.json", source_tool="cursor")
-            ]
-        return []
+            )
+        if recursive:
+            for f in _recursive_glob(root, ".cursor/hooks.json"):
+                resolved = str(f.resolve())
+                if resolved not in seen_paths:
+                    seen_paths.add(resolved)
+                    results.append(
+                        parse_file(f, ComponentType.HOOKS, name="hooks.json", source_tool="cursor")
+                    )
+        return results
 
-    def _discover_mcp(self, root: Path) -> list[ParsedComponent]:
+    def _discover_mcp(self, root: Path, *, recursive: bool = False) -> list[ParsedComponent]:
+        results = []
+        seen_paths: set[str] = set()
         mcp_file = root / ".cursor" / "mcp.json"
         if mcp_file.is_file():
-            return [
+            seen_paths.add(str(mcp_file.resolve()))
+            results.append(
                 parse_file(
                     mcp_file,
                     ComponentType.MCP_CONFIG,
                     name=".cursor/mcp.json",
                     source_tool="cursor",
                 )
-            ]
-        return []
+            )
+        if recursive:
+            for f in _recursive_glob(root, ".cursor/mcp.json"):
+                resolved = str(f.resolve())
+                if resolved not in seen_paths:
+                    seen_paths.add(resolved)
+                    results.append(
+                        parse_file(
+                            f,
+                            ComponentType.MCP_CONFIG,
+                            name=".cursor/mcp.json",
+                            source_tool="cursor",
+                        )
+                    )
+        return results

--- a/src/harness_eval/core/discoverers/gemini.py
+++ b/src/harness_eval/core/discoverers/gemini.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from harness_eval.core.discoverers.base import ToolDiscoverer, parse_file
+from harness_eval.core.discoverers.base import ToolDiscoverer, _recursive_glob, parse_file
 from harness_eval.core.types import ComponentType, ParsedComponent
 
 
@@ -22,19 +22,26 @@ class GeminiDiscoverer(ToolDiscoverer):
     def detect(self, root: Path) -> bool:
         return (root / "GEMINI.md").is_file() or (root / ".gemini").is_dir()
 
-    def discover(self, root: Path, user_config_dir: Path | None = None) -> list[ParsedComponent]:
+    def discover(
+        self, root: Path, user_config_dir: Path | None = None, *, recursive: bool = False
+    ) -> list[ParsedComponent]:
         results: list[ParsedComponent] = []
-        results.extend(self._discover_instructions(root))
-        results.extend(self._discover_commands(root))
+        results.extend(self._discover_instructions(root, recursive=recursive))
+        results.extend(self._discover_commands(root, recursive=recursive))
         return results
 
-    def collect_paths(self, root: Path, user_config_dir: Path | None = None) -> list[Path]:
+    def collect_paths(
+        self, root: Path, user_config_dir: Path | None = None, *, recursive: bool = False
+    ) -> list[Path]:
         paths: list[Path] = []
 
         # Gemini instructions
         gemini_md = root / "GEMINI.md"
         if gemini_md.is_file():
             paths.append(gemini_md)
+        if recursive:
+            for f in _recursive_glob(root, "GEMINI.md"):
+                paths.append(f)
 
         # Gemini commands
         gemini_commands = root / ".gemini" / "commands"
@@ -42,23 +49,46 @@ class GeminiDiscoverer(ToolDiscoverer):
             for f in sorted(gemini_commands.iterdir()):
                 if f.is_file() and (f.suffix == ".toml" or f.suffix == ".md"):
                     paths.append(f)
+        if recursive:
+            for f in _recursive_glob(root, ".gemini/commands/*.md"):
+                paths.append(f)
 
         return paths
 
-    def _discover_instructions(self, root: Path) -> list[ParsedComponent]:
+    def _discover_instructions(
+        self, root: Path, *, recursive: bool = False
+    ) -> list[ParsedComponent]:
+        results = []
+        seen_paths: set[str] = set()
         gemini_md = root / "GEMINI.md"
         if gemini_md.is_file():
-            return [parse_file(gemini_md, ComponentType.CLAUDE_MD, source_tool="gemini")]
-        return []
+            seen_paths.add(str(gemini_md.resolve()))
+            results.append(parse_file(gemini_md, ComponentType.CLAUDE_MD, source_tool="gemini"))
+        if recursive:
+            for f in _recursive_glob(root, "GEMINI.md"):
+                resolved = str(f.resolve())
+                if resolved not in seen_paths:
+                    seen_paths.add(resolved)
+                    results.append(parse_file(f, ComponentType.CLAUDE_MD, source_tool="gemini"))
+        return results
 
-    def _discover_commands(self, root: Path) -> list[ParsedComponent]:
+    def _discover_commands(self, root: Path, *, recursive: bool = False) -> list[ParsedComponent]:
         results = []
+        seen_paths: set[str] = set()
         commands_dir = root / ".gemini" / "commands"
-        if not commands_dir.is_dir():
-            return results
-        for f in sorted(commands_dir.iterdir()):
-            if f.is_file() and (f.suffix == ".toml" or f.suffix == ".md"):
-                results.append(
-                    parse_file(f, ComponentType.COMMAND, name=f.stem, source_tool="gemini")
-                )
+        if commands_dir.is_dir():
+            for f in sorted(commands_dir.iterdir()):
+                if f.is_file() and (f.suffix == ".toml" or f.suffix == ".md"):
+                    seen_paths.add(str(f.resolve()))
+                    results.append(
+                        parse_file(f, ComponentType.COMMAND, name=f.stem, source_tool="gemini")
+                    )
+        if recursive:
+            for f in _recursive_glob(root, ".gemini/commands/*.md"):
+                resolved = str(f.resolve())
+                if resolved not in seen_paths:
+                    seen_paths.add(resolved)
+                    results.append(
+                        parse_file(f, ComponentType.COMMAND, name=f.stem, source_tool="gemini")
+                    )
         return results

--- a/src/harness_eval/core/discoverers/opencode.py
+++ b/src/harness_eval/core/discoverers/opencode.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from harness_eval.core.discoverers.base import ToolDiscoverer, parse_file
+from harness_eval.core.discoverers.base import ToolDiscoverer, _recursive_glob, parse_file
 from harness_eval.core.types import ComponentType, ParsedComponent
 
 
@@ -28,20 +28,27 @@ class OpenCodeDiscoverer(ToolDiscoverer):
         """
         return (root / "AGENTS.md").is_file() or (root / ".opencode").is_dir()
 
-    def discover(self, root: Path, user_config_dir: Path | None = None) -> list[ParsedComponent]:
+    def discover(
+        self, root: Path, user_config_dir: Path | None = None, *, recursive: bool = False
+    ) -> list[ParsedComponent]:
         results: list[ParsedComponent] = []
-        results.extend(self._discover_instructions(root))
-        results.extend(self._discover_commands(root))
-        results.extend(self._discover_agents(root))
+        results.extend(self._discover_instructions(root, recursive=recursive))
+        results.extend(self._discover_commands(root, recursive=recursive))
+        results.extend(self._discover_agents(root, recursive=recursive))
         return results
 
-    def collect_paths(self, root: Path, user_config_dir: Path | None = None) -> list[Path]:
+    def collect_paths(
+        self, root: Path, user_config_dir: Path | None = None, *, recursive: bool = False
+    ) -> list[Path]:
         paths: list[Path] = []
 
         # OpenCode instructions
         agents_md = root / "AGENTS.md"
         if agents_md.is_file():
             paths.append(agents_md)
+        if recursive:
+            for f in _recursive_glob(root, "AGENTS.md"):
+                paths.append(f)
 
         # OpenCode commands
         opencode_commands = root / ".opencode" / "commands"
@@ -49,6 +56,9 @@ class OpenCodeDiscoverer(ToolDiscoverer):
             for f in sorted(opencode_commands.iterdir()):
                 if f.is_file() and f.suffix == ".md":
                     paths.append(f)
+        if recursive:
+            for f in _recursive_glob(root, ".opencode/commands/*.md"):
+                paths.append(f)
 
         # OpenCode agents
         opencode_agents = root / ".opencode" / "agents"
@@ -56,33 +66,63 @@ class OpenCodeDiscoverer(ToolDiscoverer):
             for f in sorted(opencode_agents.glob("*.md")):
                 if f.is_file():
                     paths.append(f)
+        if recursive:
+            for f in _recursive_glob(root, ".opencode/agents/*.md"):
+                paths.append(f)
 
         return paths
 
-    def _discover_instructions(self, root: Path) -> list[ParsedComponent]:
+    def _discover_instructions(
+        self, root: Path, *, recursive: bool = False
+    ) -> list[ParsedComponent]:
+        results = []
+        seen_paths: set[str] = set()
         agents_md = root / "AGENTS.md"
         if agents_md.is_file():
-            return [parse_file(agents_md, ComponentType.CLAUDE_MD, source_tool="agents-md")]
-        return []
-
-    def _discover_commands(self, root: Path) -> list[ParsedComponent]:
-        results = []
-        commands_dir = root / ".opencode" / "commands"
-        if not commands_dir.is_dir():
-            return results
-        for f in sorted(commands_dir.iterdir()):
-            if f.is_file() and f.suffix == ".md":
-                results.append(
-                    parse_file(f, ComponentType.COMMAND, name=f.stem, source_tool="opencode")
-                )
+            seen_paths.add(str(agents_md.resolve()))
+            results.append(parse_file(agents_md, ComponentType.CLAUDE_MD, source_tool="agents-md"))
+        if recursive:
+            for f in _recursive_glob(root, "AGENTS.md"):
+                resolved = str(f.resolve())
+                if resolved not in seen_paths:
+                    seen_paths.add(resolved)
+                    results.append(parse_file(f, ComponentType.CLAUDE_MD, source_tool="agents-md"))
         return results
 
-    def _discover_agents(self, root: Path) -> list[ParsedComponent]:
+    def _discover_commands(self, root: Path, *, recursive: bool = False) -> list[ParsedComponent]:
         results = []
+        seen_paths: set[str] = set()
+        commands_dir = root / ".opencode" / "commands"
+        if commands_dir.is_dir():
+            for f in sorted(commands_dir.iterdir()):
+                if f.is_file() and f.suffix == ".md":
+                    seen_paths.add(str(f.resolve()))
+                    results.append(
+                        parse_file(f, ComponentType.COMMAND, name=f.stem, source_tool="opencode")
+                    )
+        if recursive:
+            for f in _recursive_glob(root, ".opencode/commands/*.md"):
+                resolved = str(f.resolve())
+                if resolved not in seen_paths:
+                    seen_paths.add(resolved)
+                    results.append(
+                        parse_file(f, ComponentType.COMMAND, name=f.stem, source_tool="opencode")
+                    )
+        return results
+
+    def _discover_agents(self, root: Path, *, recursive: bool = False) -> list[ParsedComponent]:
+        results = []
+        seen_paths: set[str] = set()
         agents_dir = root / ".opencode" / "agents"
-        if not agents_dir.is_dir():
-            return results
-        for f in sorted(agents_dir.glob("*.md")):
-            if f.is_file():
-                results.append(parse_file(f, ComponentType.AGENT, source_tool="opencode"))
+        if agents_dir.is_dir():
+            for f in sorted(agents_dir.glob("*.md")):
+                if f.is_file():
+                    seen_paths.add(str(f.resolve()))
+                    results.append(parse_file(f, ComponentType.AGENT, source_tool="opencode"))
+        if recursive:
+            for f in _recursive_glob(root, ".opencode/agents/*.md"):
+                resolved = str(f.resolve())
+                if resolved not in seen_paths:
+                    seen_paths.add(resolved)
+                    results.append(parse_file(f, ComponentType.AGENT, source_tool="opencode"))
         return results

--- a/src/harness_eval/core/discoverers/third_party.py
+++ b/src/harness_eval/core/discoverers/third_party.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from harness_eval.core.discoverers.base import ToolDiscoverer, parse_file
+from harness_eval.core.discoverers.base import ToolDiscoverer, _recursive_glob, parse_file
 from harness_eval.core.types import ComponentType, ParsedComponent
 
 
@@ -22,68 +22,90 @@ class ThirdPartyDiscoverer(ToolDiscoverer):
     def detect(self, root: Path) -> bool:
         return (root / ".lola" / "modules").is_dir()
 
-    def discover(self, root: Path, user_config_dir: Path | None = None) -> list[ParsedComponent]:
+    def discover(
+        self, root: Path, user_config_dir: Path | None = None, *, recursive: bool = False
+    ) -> list[ParsedComponent]:
         results: list[ParsedComponent] = []
+        seen_paths: set[str] = set()
         modules_dir = root / ".lola" / "modules"
-        if not modules_dir.is_dir():
-            return results
+        if modules_dir.is_dir():
+            for module_dir in sorted(modules_dir.iterdir()):
+                if not module_dir.is_dir():
+                    continue
 
-        for module_dir in sorted(modules_dir.iterdir()):
-            if not module_dir.is_dir():
-                continue
+                skills_dir = module_dir / "skills"
+                if skills_dir.is_dir():
+                    for skill_md in sorted(skills_dir.rglob("SKILL.md")):
+                        seen_paths.add(str(skill_md.resolve()))
+                        results.append(
+                            parse_file(
+                                skill_md,
+                                ComponentType.SKILL,
+                                name=skill_md.parent.name,
+                                source_tool="third-party",
+                            )
+                        )
 
-            skills_dir = module_dir / "skills"
-            if skills_dir.is_dir():
-                for skill_md in sorted(skills_dir.rglob("SKILL.md")):
+                commands_dir = module_dir / "commands"
+                if commands_dir.is_dir():
+                    for f in sorted(commands_dir.iterdir()):
+                        if f.is_file() and f.suffix == ".md":
+                            seen_paths.add(str(f.resolve()))
+                            results.append(
+                                parse_file(f, ComponentType.COMMAND, source_tool="third-party")
+                            )
+
+                agents_dir = module_dir / "agents"
+                if agents_dir.is_dir():
+                    for f in sorted(agents_dir.glob("*.md")):
+                        if f.is_file():
+                            seen_paths.add(str(f.resolve()))
+                            results.append(
+                                parse_file(f, ComponentType.AGENT, source_tool="third-party")
+                            )
+
+        if recursive:
+            for f in _recursive_glob(root, ".lola/modules/*/skills/*/SKILL.md"):
+                resolved = str(f.resolve())
+                if resolved not in seen_paths:
+                    seen_paths.add(resolved)
                     results.append(
                         parse_file(
-                            skill_md,
+                            f,
                             ComponentType.SKILL,
-                            name=skill_md.parent.name,
+                            name=f.parent.name,
                             source_tool="third-party",
                         )
                     )
 
-            commands_dir = module_dir / "commands"
-            if commands_dir.is_dir():
-                for f in sorted(commands_dir.iterdir()):
-                    if f.is_file() and f.suffix == ".md":
-                        results.append(
-                            parse_file(f, ComponentType.COMMAND, source_tool="third-party")
-                        )
-
-            agents_dir = module_dir / "agents"
-            if agents_dir.is_dir():
-                for f in sorted(agents_dir.glob("*.md")):
-                    if f.is_file():
-                        results.append(
-                            parse_file(f, ComponentType.AGENT, source_tool="third-party")
-                        )
-
         return results
 
-    def collect_paths(self, root: Path, user_config_dir: Path | None = None) -> list[Path]:
+    def collect_paths(
+        self, root: Path, user_config_dir: Path | None = None, *, recursive: bool = False
+    ) -> list[Path]:
         paths: list[Path] = []
         modules_dir = root / ".lola" / "modules"
-        if not modules_dir.is_dir():
-            return paths
+        if modules_dir.is_dir():
+            for module_dir in sorted(modules_dir.iterdir()):
+                if not module_dir.is_dir():
+                    continue
+                skills_dir = module_dir / "skills"
+                if skills_dir.is_dir():
+                    for f in sorted(skills_dir.rglob("SKILL.md")):
+                        paths.append(f)
+                commands_dir = module_dir / "commands"
+                if commands_dir.is_dir():
+                    for f in sorted(commands_dir.iterdir()):
+                        if f.is_file() and f.suffix == ".md":
+                            paths.append(f)
+                agents_dir = module_dir / "agents"
+                if agents_dir.is_dir():
+                    for f in sorted(agents_dir.glob("*.md")):
+                        if f.is_file():
+                            paths.append(f)
 
-        for module_dir in sorted(modules_dir.iterdir()):
-            if not module_dir.is_dir():
-                continue
-            skills_dir = module_dir / "skills"
-            if skills_dir.is_dir():
-                for f in sorted(skills_dir.rglob("SKILL.md")):
-                    paths.append(f)
-            commands_dir = module_dir / "commands"
-            if commands_dir.is_dir():
-                for f in sorted(commands_dir.iterdir()):
-                    if f.is_file() and f.suffix == ".md":
-                        paths.append(f)
-            agents_dir = module_dir / "agents"
-            if agents_dir.is_dir():
-                for f in sorted(agents_dir.glob("*.md")):
-                    if f.is_file():
-                        paths.append(f)
+        if recursive:
+            for f in _recursive_glob(root, ".lola/modules/*/skills/*/SKILL.md"):
+                paths.append(f)
 
         return paths

--- a/src/harness_eval/core/setup.py
+++ b/src/harness_eval/core/setup.py
@@ -18,6 +18,8 @@ def discover_setup(
     name: str,
     path: str,
     user_config_dir: str | None = None,
+    *,
+    recursive: bool = False,
 ) -> Setup:
     """Walk a directory and discover all agent-relevant components."""
     root = Path(path)
@@ -29,7 +31,7 @@ def discover_setup(
     components: list[ParsedComponent] = []
 
     for discoverer in get_all_discoverers():
-        components.extend(discoverer.discover(root, user_config_dir=user_dir))
+        components.extend(discoverer.discover(root, user_config_dir=user_dir, recursive=recursive))
 
     components = _deduplicate_components(components)
     components.extend(_discover_uncategorized(root, components))
@@ -51,6 +53,8 @@ def discover_setup(
 def collect_setup_file_paths(
     root: Path,
     user_config_dir: Path | None = None,
+    *,
+    recursive: bool = False,
 ) -> list[Path]:
     """Return deduplicated file paths that ``discover_setup`` would scan.
 
@@ -61,7 +65,9 @@ def collect_setup_file_paths(
     paths: list[Path] = []
 
     for discoverer in get_all_discoverers():
-        paths.extend(discoverer.collect_paths(root, user_config_dir=user_config_dir))
+        paths.extend(
+            discoverer.collect_paths(root, user_config_dir=user_config_dir, recursive=recursive)
+        )
 
     # Deduplicate while preserving order
     seen: set[str] = set()

--- a/tests/test_recursive_discovery.py
+++ b/tests/test_recursive_discovery.py
@@ -1,0 +1,147 @@
+"""Tests for recursive discovery, symlink safety, and deduplication."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from harness_eval.core.discoverers.base import _recursive_glob
+from harness_eval.core.setup import discover_setup
+from harness_eval.core.types import ComponentType
+
+
+@pytest.fixture
+def nested_skills_tree(tmp_path: Path) -> Path:
+    """Create a project tree with skills at multiple nesting levels."""
+    # Root-level CLAUDE.md (so Claude Code discoverer detects the project)
+    (tmp_path / "CLAUDE.md").write_text("# Root\n")
+
+    # Root-level skill
+    root_skill = tmp_path / "skills" / "root-skill"
+    root_skill.mkdir(parents=True)
+    (root_skill / "SKILL.md").write_text("---\nname: root-skill\n---\nRoot skill.\n")
+
+    # Nested skill at apps/frontend/skills/
+    nested_skill = tmp_path / "apps" / "frontend" / "skills" / "nested-skill"
+    nested_skill.mkdir(parents=True)
+    (nested_skill / "SKILL.md").write_text("---\nname: nested-skill\n---\nNested skill.\n")
+
+    # Deeply nested skill at packages/core/skills/
+    deep_skill = tmp_path / "packages" / "core" / "skills" / "deep-skill"
+    deep_skill.mkdir(parents=True)
+    (deep_skill / "SKILL.md").write_text("---\nname: deep-skill\n---\nDeep skill.\n")
+
+    return tmp_path
+
+
+class TestRecursiveDiscovery:
+    def test_recursive_discovers_nested_configs(self, nested_skills_tree: Path) -> None:
+        setup = discover_setup("test", str(nested_skills_tree), recursive=True)
+        skills = setup.by_type(ComponentType.SKILL)
+        skill_names = {s.name for s in skills}
+        assert "root-skill" in skill_names
+        assert "nested-skill" in skill_names
+        assert "deep-skill" in skill_names
+
+    def test_non_recursive_skips_nested(self, nested_skills_tree: Path) -> None:
+        setup = discover_setup("test", str(nested_skills_tree), recursive=False)
+        skills = setup.by_type(ComponentType.SKILL)
+        skill_names = {s.name for s in skills}
+        assert "root-skill" in skill_names
+        assert "nested-skill" not in skill_names
+        assert "deep-skill" not in skill_names
+
+
+class TestExcludedDirectories:
+    def test_excluded_directories_are_skipped(self, tmp_path: Path) -> None:
+        (tmp_path / "CLAUDE.md").write_text("# Root\n")
+
+        # Skill inside node_modules (should be excluded)
+        excluded_skill = tmp_path / "node_modules" / "pkg" / "skills" / "bad-skill"
+        excluded_skill.mkdir(parents=True)
+        (excluded_skill / "SKILL.md").write_text("---\nname: bad-skill\n---\nShould skip.\n")
+
+        # Skill outside node_modules (should be found)
+        good_skill = tmp_path / "lib" / "skills" / "good-skill"
+        good_skill.mkdir(parents=True)
+        (good_skill / "SKILL.md").write_text("---\nname: good-skill\n---\nShould find.\n")
+
+        setup = discover_setup("test", str(tmp_path), recursive=True)
+        skills = setup.by_type(ComponentType.SKILL)
+        skill_names = {s.name for s in skills}
+        assert "good-skill" in skill_names
+        assert "bad-skill" not in skill_names
+
+
+class TestDeduplication:
+    def test_deduplication(self, nested_skills_tree: Path) -> None:
+        setup = discover_setup("test", str(nested_skills_tree), recursive=True)
+        skills = setup.by_type(ComponentType.SKILL)
+        paths = [s.path for s in skills]
+        # No path should appear more than once
+        assert len(paths) == len(set(paths))
+
+    def test_root_skill_not_duplicated(self, tmp_path: Path) -> None:
+        """A root-level skill should not be reported twice with recursive=True."""
+        (tmp_path / "CLAUDE.md").write_text("# Root\n")
+        skill = tmp_path / "skills" / "only-skill"
+        skill.mkdir(parents=True)
+        (skill / "SKILL.md").write_text("---\nname: only-skill\n---\nOnly skill.\n")
+
+        setup = discover_setup("test", str(tmp_path), recursive=True)
+        skills = setup.by_type(ComponentType.SKILL)
+        matching = [s for s in skills if s.name == "only-skill"]
+        assert len(matching) == 1
+
+
+class TestSymlinkSafety:
+    def test_symlink_outside_repo_is_skipped(self, tmp_path: Path) -> None:
+        """Symlinks pointing outside the project root are skipped."""
+        project = tmp_path / "project"
+        project.mkdir()
+
+        outside = tmp_path / "outside"
+        outside.mkdir()
+
+        # Create a real skill outside the project
+        outside_skill = outside / "skills" / "external-skill"
+        outside_skill.mkdir(parents=True)
+        (outside_skill / "SKILL.md").write_text("---\nname: external-skill\n---\nExternal.\n")
+
+        # Symlink from inside the project to outside
+        link_dir = project / "linked-stuff" / "skills" / "external-skill"
+        link_dir.parent.mkdir(parents=True)
+        os.symlink(outside_skill / "SKILL.md", link_dir.parent / "SKILL.md")
+
+        results = _recursive_glob(project, "skills/*/SKILL.md")
+        resolved_paths = {str(r.resolve()) for r in results}
+        assert str((outside_skill / "SKILL.md").resolve()) not in resolved_paths
+
+    def test_symlink_inside_repo_is_kept(self, tmp_path: Path) -> None:
+        """Symlinks pointing within the project root are kept."""
+        # Create a real skill
+        real_skill = tmp_path / "skills" / "real-skill"
+        real_skill.mkdir(parents=True)
+        (real_skill / "SKILL.md").write_text("---\nname: real-skill\n---\nReal.\n")
+
+        # Create a symlink within the project
+        link_skill = tmp_path / "apps" / "skills" / "link-skill"
+        link_skill.mkdir(parents=True)
+        os.symlink(real_skill / "SKILL.md", link_skill / "SKILL.md")
+
+        results = _recursive_glob(tmp_path, "skills/*/SKILL.md")
+        result_names = {r.parent.name for r in results}
+        assert "real-skill" in result_names
+        assert "link-skill" in result_names
+
+    def test_broken_symlink_is_skipped(self, tmp_path: Path) -> None:
+        """Broken symlinks are skipped without raising errors."""
+        skill_dir = tmp_path / "skills" / "broken-skill"
+        skill_dir.mkdir(parents=True)
+        os.symlink("/nonexistent/path/SKILL.md", skill_dir / "SKILL.md")
+
+        # Should not raise
+        results = _recursive_glob(tmp_path, "skills/*/SKILL.md")
+        assert len(results) == 0


### PR DESCRIPTION
## Summary

Adds a `--recursive` flag to lint and security commands that searches the entire directory tree for agent config files, not just the root-level paths.

### Why

Repos like fullsend have agent configs in nested directories (`internal/scaffold/fullsend-repo/skills/`, `internal/scaffold/fullsend-repo/agents/`). Without recursive mode, these are invisible. With it, harness-eval finds them automatically.

| Repo | Without --recursive | With --recursive |
|---|---|---|
| harness-eval (own repo) | 18 components | 47 components |
| fullsend | 18 components | 29 components |

### What it searches

When `--recursive` is enabled, each discoverer additionally searches `**/` patterns:
- Claude Code: `**/skills/*/SKILL.md`, `**/commands/*.md`, `**/agents/*.md`, `**/.claude/settings.json`
- OpenCode: `**/AGENTS.md`, `**/.opencode/commands/*.md`, `**/.opencode/agents/*.md`
- Copilot: `**/.github/skills/*/SKILL.md`, `**/.github/prompts/*.md`, `**/.github/agents/*.md`
- Gemini: `**/GEMINI.md`, `**/.gemini/commands/*.md`
- Cursor: `**/.cursor/rules/*.mdc`, `**/.cursorrules`, `**/.cursor/commands/*.md`
- Third-party: `**/.lola/modules/*/skills/*/SKILL.md`

Excludes: `.git`, `__pycache__`, `node_modules`, `.venv`, `vendor`, `.tox`

### Usage

CLI:
```bash
harness-eval lint . --recursive
harness-eval security . --recursive
```

GitHub Action:
```yaml
- uses: redhat-community-ai-tools/harness-eval/.github/actions/harness-eval@main
  with:
    recursive: "true"
```

Default is off. Behavior unchanged unless the user opts in.

## Checklist

- [x] `uv run pytest tests/ -q` passes (465 tests)
- [x] `uv run ruff check src/ tests/` clean
- [x] `uv run ruff format --check src/ tests/` clean
- [x] `uv run harness-eval security . --fail-on-warning` clean
- [x] `uv run harness-eval lint . --fail-on-error` clean
- [x] Tested on fullsend repo (18 -> 29 components)
- [x] INSTALL.md updated
- [x] CHANGELOG.md updated