### PR TITLE
feat: add Windsurf, Cline, and Copilot/Gemini/OpenCode discovery (#30)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- Windsurf discovery: `.windsurfrules` and `.windsurf/rules/*.md` mapped to CLAUDE_MD (#30)
+- Cline discovery: `.clinerules` file or `.clinerules/*.md` directory mapped to CLAUDE_MD (#30)
+- Copilot discovery: `.github/copilot-instructions.md` mapped to CLAUDE_MD (#30)
+- Gemini CLI MCP discovery: `.gemini/settings.json` and global `~/.gemini/settings.json` (`mcpServers`) mapped to MCP_CONFIG (#30)
+- OpenCode MCP discovery: `opencode.json`/`opencode.jsonc` (`mcp` key) mapped to MCP_CONFIG; MCP rules now read both `mcpServers` and OpenCode's `mcp` key (#30)
+
 ## [7.0.0] - 2026-08-04
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Evaluate AI code agent setups for best practices, redundancy, security, and cros
 
 Available as a **CLI tool**, a **GitHub Action**, a **Tekton Task** (OpenShift Pipelines), a **Claude Code plugin**, and **Cursor commands**.
 
-Supports Claude Code, Cursor, Copilot, Gemini CLI, and OpenCode projects. Auto-detects which tool(s) a project uses. Also discovers third-party modules installed via package managers.
+Supports Claude Code, Cursor, Windsurf, Cline, Copilot, Gemini CLI, and OpenCode projects. Auto-detects which tool(s) a project uses. Also discovers third-party modules installed via package managers.
 
 ## What it does
 
@@ -40,9 +40,11 @@ Auto-detects which tool(s) a project uses and evaluates all discovered component
 |-----------|------------------|
 | Claude Code | `CLAUDE.md`, `skills/`, `commands/`, `.claude/agents/`, `.claude/settings.json`, `.mcp.json` |
 | Cursor | `.cursor/rules/*.mdc`, `.cursorrules`, `.cursor/commands/`, `.cursor/skills/`, `.cursor/hooks.json`, `.cursor/mcp.json` |
-| Copilot | `.github/skills/`, `.github/prompts/`, `.github/agents/` |
-| Gemini CLI | `GEMINI.md`, `.gemini/commands/` |
-| OpenCode | `AGENTS.md`, `.opencode/commands/`, `.opencode/agents/` |
+| Windsurf | `.windsurfrules`, `.windsurf/rules/*.md` |
+| Cline | `.clinerules` (file or directory of `*.md`) |
+| Copilot | `.github/copilot-instructions.md`, `.github/skills/`, `.github/prompts/`, `.github/agents/` |
+| Gemini CLI | `GEMINI.md`, `.gemini/commands/`, `.gemini/settings.json` (MCP) |
+| OpenCode | `AGENTS.md`, `.opencode/commands/`, `.opencode/agents/`, `opencode.json` (MCP) |
 | Third-party modules | `.lola/modules/` (skills, commands, agents installed via package managers) |
 
 Multi-tool projects are fully supported. When a project contains files for multiple assistants, all are discovered, deduplicated, and evaluated together.

--- a/src/harness_eval/core/discoverers/base.py
+++ b/src/harness_eval/core/discoverers/base.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from abc import ABC, abstractmethod
 from pathlib import Path
 
@@ -41,6 +42,20 @@ def _recursive_glob(root: Path, pattern: str) -> list[Path]:
             continue
         results.append(f)
     return results
+
+
+def _json_top_level_keys(filepath: Path) -> set[str]:
+    """Return the set of top-level keys in a JSON file, or empty on any error.
+
+    Used to gate MCP-config discovery so that non-MCP config files (e.g. a
+    Gemini settings.json with only editor prefs) are not treated as MCP
+    configs and flagged by MCP rules.
+    """
+    try:
+        data = json.loads(filepath.read_text(encoding="utf-8", errors="replace"))
+    except (json.JSONDecodeError, ValueError, OSError):
+        return set()
+    return set(data.keys()) if isinstance(data, dict) else set()
 
 
 def parse_file(

--- a/src/harness_eval/core/discoverers/cline.py
+++ b/src/harness_eval/core/discoverers/cline.py
@@ -1,0 +1,81 @@
+"""Cline setup discoverer."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from harness_eval.core.discoverers.base import ToolDiscoverer, _recursive_glob, parse_file
+from harness_eval.core.types import ComponentType, ParsedComponent
+
+
+class ClineDiscoverer(ToolDiscoverer):
+    """Discovers Cline setup components.
+
+    Cline supports either a single ``.clinerules`` file or a ``.clinerules/``
+    directory of per-topic markdown files. Both map to CLAUDE_MD components.
+    """
+
+    @property
+    def tool_name(self) -> str:
+        return "Cline"
+
+    @property
+    def source_tool(self) -> str:
+        return "cline"
+
+    def detect(self, root: Path) -> bool:
+        target = root / ".clinerules"
+        return target.is_file() or target.is_dir()
+
+    def discover(
+        self, root: Path, user_config_dir: Path | None = None, *, recursive: bool = False
+    ) -> list[ParsedComponent]:
+        return self._discover_rules(root, recursive=recursive)
+
+    def collect_paths(
+        self, root: Path, user_config_dir: Path | None = None, *, recursive: bool = False
+    ) -> list[Path]:
+        paths: list[Path] = []
+
+        target = root / ".clinerules"
+        if target.is_file():
+            paths.append(target)
+        elif target.is_dir():
+            for f in sorted(target.rglob("*.md")):
+                if f.is_file():
+                    paths.append(f)
+        if recursive:
+            paths.extend(_recursive_glob(root, ".clinerules"))
+            paths.extend(_recursive_glob(root, ".clinerules/*.md"))
+
+        return paths
+
+    def _discover_rules(self, root: Path, *, recursive: bool = False) -> list[ParsedComponent]:
+        results: list[ParsedComponent] = []
+        seen_paths: set[str] = set()
+
+        def _add(f: Path, name: str) -> None:
+            if not f.is_file():
+                return
+            resolved = str(f.resolve())
+            if resolved not in seen_paths:
+                seen_paths.add(resolved)
+                results.append(
+                    parse_file(f, ComponentType.CLAUDE_MD, name=name, source_tool="cline")
+                )
+
+        target = root / ".clinerules"
+        if target.is_file():
+            _add(target, ".clinerules")
+        elif target.is_dir():
+            for f in sorted(target.rglob("*.md")):
+                _add(f, f.stem)
+
+        if recursive:
+            for f in _recursive_glob(root, ".clinerules"):
+                rel = f.relative_to(root)
+                _add(f, str(rel) if rel != Path(".clinerules") else ".clinerules")
+            for f in _recursive_glob(root, ".clinerules/*.md"):
+                _add(f, f.stem)
+
+        return results

--- a/src/harness_eval/core/discoverers/copilot.py
+++ b/src/harness_eval/core/discoverers/copilot.py
@@ -24,12 +24,14 @@ class CopilotDiscoverer(ToolDiscoverer):
             (root / ".github" / "prompts").is_dir()
             or (root / ".github" / "agents").is_dir()
             or (root / ".github" / "skills").is_dir()
+            or (root / ".github" / "copilot-instructions.md").is_file()
         )
 
     def discover(
         self, root: Path, user_config_dir: Path | None = None, *, recursive: bool = False
     ) -> list[ParsedComponent]:
         results: list[ParsedComponent] = []
+        results.extend(self._discover_instructions(root))
         results.extend(self._discover_skills(root, recursive=recursive))
         results.extend(self._discover_commands(root, recursive=recursive))
         results.extend(self._discover_agents(root, recursive=recursive))
@@ -39,6 +41,10 @@ class CopilotDiscoverer(ToolDiscoverer):
         self, root: Path, user_config_dir: Path | None = None, *, recursive: bool = False
     ) -> list[Path]:
         paths: list[Path] = []
+
+        instructions = root / ".github" / "copilot-instructions.md"
+        if instructions.is_file():
+            paths.append(instructions)
 
         # Copilot skills
         copilot_skills = root / ".github" / "skills"
@@ -70,6 +76,19 @@ class CopilotDiscoverer(ToolDiscoverer):
                 paths.append(f)
 
         return paths
+
+    def _discover_instructions(self, root: Path) -> list[ParsedComponent]:
+        instructions = root / ".github" / "copilot-instructions.md"
+        if instructions.is_file():
+            return [
+                parse_file(
+                    instructions,
+                    ComponentType.CLAUDE_MD,
+                    name="copilot-instructions",
+                    source_tool="copilot",
+                )
+            ]
+        return []
 
     def _discover_skills(self, root: Path, *, recursive: bool = False) -> list[ParsedComponent]:
         results = []

--- a/src/harness_eval/core/discoverers/gemini.py
+++ b/src/harness_eval/core/discoverers/gemini.py
@@ -4,7 +4,12 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from harness_eval.core.discoverers.base import ToolDiscoverer, _recursive_glob, parse_file
+from harness_eval.core.discoverers.base import (
+    ToolDiscoverer,
+    _json_top_level_keys,
+    _recursive_glob,
+    parse_file,
+)
 from harness_eval.core.types import ComponentType, ParsedComponent
 
 
@@ -28,6 +33,7 @@ class GeminiDiscoverer(ToolDiscoverer):
         results: list[ParsedComponent] = []
         results.extend(self._discover_instructions(root, recursive=recursive))
         results.extend(self._discover_commands(root, recursive=recursive))
+        results.extend(self._discover_mcp(root, user_config_dir))
         return results
 
     def collect_paths(
@@ -52,6 +58,14 @@ class GeminiDiscoverer(ToolDiscoverer):
         if recursive:
             for f in _recursive_glob(root, ".gemini/commands/*.md"):
                 paths.append(f)
+
+        settings = root / ".gemini" / "settings.json"
+        if settings.is_file():
+            paths.append(settings)
+        if user_config_dir is not None:
+            global_settings = user_config_dir / "settings.json"
+            if global_settings.is_file():
+                paths.append(global_settings)
 
         return paths
 
@@ -91,4 +105,35 @@ class GeminiDiscoverer(ToolDiscoverer):
                     results.append(
                         parse_file(f, ComponentType.COMMAND, name=f.stem, source_tool="gemini")
                     )
+        return results
+
+    def _discover_mcp(
+        self, root: Path, user_config_dir: Path | None = None
+    ) -> list[ParsedComponent]:
+        # Gemini CLI stores MCP servers in settings.json under the standard
+        # 'mcpServers' key -- project-level (.gemini/settings.json) and global
+        # (~/.gemini/settings.json, passed via --user-config). Only treat a file
+        # as an MCP config when that key is present, so ordinary settings files
+        # are not misclassified.
+        results: list[ParsedComponent] = []
+        seen: set[str] = set()
+        candidates = [(root / ".gemini" / "settings.json", ".gemini/settings.json")]
+        if user_config_dir is not None:
+            candidates.append((user_config_dir / "settings.json", "~/.gemini/settings.json"))
+        for path, name in candidates:
+            if not path.is_file():
+                continue
+            resolved = str(path.resolve())
+            if resolved in seen:
+                continue
+            if "mcpServers" in _json_top_level_keys(path):
+                seen.add(resolved)
+                results.append(
+                    parse_file(
+                        path,
+                        ComponentType.MCP_CONFIG,
+                        name=name,
+                        source_tool="gemini",
+                    )
+                )
         return results

--- a/src/harness_eval/core/discoverers/opencode.py
+++ b/src/harness_eval/core/discoverers/opencode.py
@@ -4,7 +4,12 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from harness_eval.core.discoverers.base import ToolDiscoverer, _recursive_glob, parse_file
+from harness_eval.core.discoverers.base import (
+    ToolDiscoverer,
+    _json_top_level_keys,
+    _recursive_glob,
+    parse_file,
+)
 from harness_eval.core.types import ComponentType, ParsedComponent
 
 
@@ -26,7 +31,12 @@ class OpenCodeDiscoverer(ToolDiscoverer):
         Claude Code, OpenCode) so it is attributed as "agents-md" rather than
         "opencode".  The .opencode/ directory is OpenCode-specific.
         """
-        return (root / "AGENTS.md").is_file() or (root / ".opencode").is_dir()
+        return (
+            (root / "AGENTS.md").is_file()
+            or (root / ".opencode").is_dir()
+            or (root / "opencode.json").is_file()
+            or (root / "opencode.jsonc").is_file()
+        )
 
     def discover(
         self, root: Path, user_config_dir: Path | None = None, *, recursive: bool = False
@@ -35,6 +45,7 @@ class OpenCodeDiscoverer(ToolDiscoverer):
         results.extend(self._discover_instructions(root, recursive=recursive))
         results.extend(self._discover_commands(root, recursive=recursive))
         results.extend(self._discover_agents(root, recursive=recursive))
+        results.extend(self._discover_mcp(root))
         return results
 
     def collect_paths(
@@ -69,6 +80,11 @@ class OpenCodeDiscoverer(ToolDiscoverer):
         if recursive:
             for f in _recursive_glob(root, ".opencode/agents/*.md"):
                 paths.append(f)
+
+        for cfg_name in ("opencode.json", "opencode.jsonc"):
+            cfg = root / cfg_name
+            if cfg.is_file():
+                paths.append(cfg)
 
         return paths
 
@@ -126,3 +142,20 @@ class OpenCodeDiscoverer(ToolDiscoverer):
                     seen_paths.add(resolved)
                     results.append(parse_file(f, ComponentType.AGENT, source_tool="opencode"))
         return results
+
+    def _discover_mcp(self, root: Path) -> list[ParsedComponent]:
+        # OpenCode stores MCP servers in opencode.json(c) under the 'mcp' key.
+        # Only emit an MCP config component when that key is present so that
+        # non-MCP OpenCode configs are not misclassified.
+        for cfg_name in ("opencode.json", "opencode.jsonc"):
+            cfg = root / cfg_name
+            if cfg.is_file() and "mcp" in _json_top_level_keys(cfg):
+                return [
+                    parse_file(
+                        cfg,
+                        ComponentType.MCP_CONFIG,
+                        name=cfg_name,
+                        source_tool="opencode",
+                    )
+                ]
+        return []

--- a/src/harness_eval/core/discoverers/registry.py
+++ b/src/harness_eval/core/discoverers/registry.py
@@ -4,15 +4,19 @@ from __future__ import annotations
 
 from harness_eval.core.discoverers.base import ToolDiscoverer
 from harness_eval.core.discoverers.claude import ClaudeCodeDiscoverer
+from harness_eval.core.discoverers.cline import ClineDiscoverer
 from harness_eval.core.discoverers.copilot import CopilotDiscoverer
 from harness_eval.core.discoverers.cursor import CursorDiscoverer
 from harness_eval.core.discoverers.gemini import GeminiDiscoverer
 from harness_eval.core.discoverers.opencode import OpenCodeDiscoverer
 from harness_eval.core.discoverers.third_party import ThirdPartyDiscoverer
+from harness_eval.core.discoverers.windsurf import WindsurfDiscoverer
 
 DISCOVERERS: list[ToolDiscoverer] = [
     ClaudeCodeDiscoverer(),
     CursorDiscoverer(),
+    WindsurfDiscoverer(),
+    ClineDiscoverer(),
     CopilotDiscoverer(),
     GeminiDiscoverer(),
     OpenCodeDiscoverer(),

--- a/src/harness_eval/core/discoverers/windsurf.py
+++ b/src/harness_eval/core/discoverers/windsurf.py
@@ -1,0 +1,87 @@
+"""Windsurf setup discoverer."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from harness_eval.core.discoverers.base import ToolDiscoverer, _recursive_glob, parse_file
+from harness_eval.core.types import ComponentType, ParsedComponent
+
+
+class WindsurfDiscoverer(ToolDiscoverer):
+    """Discovers Windsurf setup components.
+
+    Windsurf stores its system instructions as plain markdown, mirroring
+    Cursor: a single ``.windsurfrules`` file and/or per-topic files under
+    ``.windsurf/rules/``. Both map to CLAUDE_MD components.
+    """
+
+    @property
+    def tool_name(self) -> str:
+        return "Windsurf"
+
+    @property
+    def source_tool(self) -> str:
+        return "windsurf"
+
+    def detect(self, root: Path) -> bool:
+        return (root / ".windsurf").is_dir() or (root / ".windsurfrules").is_file()
+
+    def discover(
+        self, root: Path, user_config_dir: Path | None = None, *, recursive: bool = False
+    ) -> list[ParsedComponent]:
+        return self._discover_rules(root, recursive=recursive)
+
+    def collect_paths(
+        self, root: Path, user_config_dir: Path | None = None, *, recursive: bool = False
+    ) -> list[Path]:
+        paths: list[Path] = []
+
+        rules_dir = root / ".windsurf" / "rules"
+        if rules_dir.is_dir():
+            for f in sorted(rules_dir.rglob("*.md")):
+                if f.is_file():
+                    paths.append(f)
+        if recursive:
+            paths.extend(_recursive_glob(root, ".windsurf/rules/*.md"))
+
+        top = root / ".windsurfrules"
+        if top.is_file():
+            paths.append(top)
+        if recursive:
+            paths.extend(_recursive_glob(root, ".windsurfrules"))
+
+        return paths
+
+    def _discover_rules(self, root: Path, *, recursive: bool = False) -> list[ParsedComponent]:
+        results: list[ParsedComponent] = []
+        seen_paths: set[str] = set()
+
+        def _add(f: Path, name: str) -> None:
+            if not f.is_file():
+                return
+            resolved = str(f.resolve())
+            if resolved not in seen_paths:
+                seen_paths.add(resolved)
+                results.append(
+                    parse_file(f, ComponentType.CLAUDE_MD, name=name, source_tool="windsurf")
+                )
+
+        rules_dir = root / ".windsurf" / "rules"
+        if rules_dir.is_dir():
+            for f in sorted(rules_dir.rglob("*.md")):
+                if f.is_file():
+                    _add(f, f.stem)
+        if recursive:
+            for f in _recursive_glob(root, ".windsurf/rules/*.md"):
+                _add(f, f.stem)
+
+        top = root / ".windsurfrules"
+        if top.is_file():
+            _add(top, ".windsurfrules")
+        if recursive:
+            for f in _recursive_glob(root, ".windsurfrules"):
+                rel = f.relative_to(root)
+                _add(f, str(rel) if rel != Path(".windsurfrules") else ".windsurfrules")
+
+        return results

--- a/src/harness_eval/inspection/rules/mcp/_shared.py
+++ b/src/harness_eval/inspection/rules/mcp/_shared.py
@@ -1,0 +1,19 @@
+"""Shared helpers for MCP configuration rules."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def extract_servers(data: dict[str, Any]) -> Any:
+    """Return the MCP servers mapping from a parsed config.
+
+    Supports the standard ``mcpServers`` key (Claude Code, Cursor, Gemini CLI)
+    and OpenCode's ``mcp`` key. Returns whatever value is under the first key
+    present (which callers validate), or ``None`` if neither key exists.
+    """
+    if "mcpServers" in data:
+        return data.get("mcpServers")
+    if "mcp" in data:
+        return data.get("mcp")
+    return None

--- a/src/harness_eval/inspection/rules/mcp/duplicate_server.py
+++ b/src/harness_eval/inspection/rules/mcp/duplicate_server.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 
 from harness_eval.core.types import ComponentType
+from harness_eval.inspection.rules.mcp._shared import extract_servers
 from harness_eval.inspection.types import (
     Location,
     ReportDescriptor,
@@ -41,7 +42,7 @@ class McpDuplicateServer:
         if not isinstance(data, dict):
             return
 
-        servers = data.get("mcpServers")
+        servers = extract_servers(data)
         if not isinstance(servers, dict):
             return
 

--- a/src/harness_eval/inspection/rules/mcp/no_wildcard_tools.py
+++ b/src/harness_eval/inspection/rules/mcp/no_wildcard_tools.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 
 from harness_eval.core.types import ComponentType
+from harness_eval.inspection.rules.mcp._shared import extract_servers
 from harness_eval.inspection.types import (
     Location,
     ReportDescriptor,
@@ -41,7 +42,7 @@ class McpNoWildcardTools:
         if not isinstance(data, dict):
             return
 
-        servers = data.get("mcpServers")
+        servers = extract_servers(data)
         if not isinstance(servers, dict):
             return
 

--- a/src/harness_eval/inspection/rules/mcp/suspicious_endpoint.py
+++ b/src/harness_eval/inspection/rules/mcp/suspicious_endpoint.py
@@ -4,6 +4,7 @@ import json
 import re
 
 from harness_eval.core.types import ComponentType
+from harness_eval.inspection.rules.mcp._shared import extract_servers
 from harness_eval.inspection.types import (
     Location,
     ReportDescriptor,
@@ -51,7 +52,7 @@ class McpSuspiciousEndpoint:
         if not isinstance(data, dict):
             return
 
-        servers = data.get("mcpServers")
+        servers = extract_servers(data)
         if not isinstance(servers, dict):
             return
 

--- a/src/harness_eval/inspection/rules/mcp/valid_config.py
+++ b/src/harness_eval/inspection/rules/mcp/valid_config.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 
 from harness_eval.core.types import ComponentType
+from harness_eval.inspection.rules.mcp._shared import extract_servers
 from harness_eval.inspection.types import (
     Location,
     ReportDescriptor,
@@ -23,8 +24,8 @@ class McpValidConfig:
         messages={
             "invalid_json": "MCP config is not valid JSON: {{error}}",
             "not_object": "MCP config root must be a JSON object",
-            "missing_servers": "MCP config has no 'mcpServers' key",
-            "servers_not_object": "'mcpServers' must be a JSON object, got {{actual_type}}",
+            "missing_servers": "MCP config has no 'mcpServers' or 'mcp' key",
+            "servers_not_object": "MCP servers must be a JSON object, got {{actual_type}}",
             "server_no_transport": "Server '{{name}}' has no 'command' (stdio) or 'url' (HTTP/SSE)",
             "args_not_array": "Server '{{name}}': 'args' must be an array, got {{actual_type}}",
             "env_not_object": "Server '{{name}}': 'env' must be an object, got {{actual_type}}",
@@ -55,7 +56,7 @@ class McpValidConfig:
             context.report(ReportDescriptor(message_id="not_object", location=loc))
             return
 
-        servers = data.get("mcpServers")
+        servers = extract_servers(data)
         if servers is None:
             context.report(ReportDescriptor(message_id="missing_servers", location=loc))
             return

--- a/tests/fixtures/sample-cline-setup/.clinerules/coding.md
+++ b/tests/fixtures/sample-cline-setup/.clinerules/coding.md
@@ -1,0 +1,3 @@
+# Coding
+
+Keep functions small. Follow PEP 8 for Python code.

--- a/tests/fixtures/sample-cline-setup/.clinerules/security.md
+++ b/tests/fixtures/sample-cline-setup/.clinerules/security.md
@@ -1,0 +1,3 @@
+# Security
+
+Never hardcode credentials. Use environment variables for secrets.

--- a/tests/fixtures/sample-windsurf-setup/.windsurf/rules/coding-standards.md
+++ b/tests/fixtures/sample-windsurf-setup/.windsurf/rules/coding-standards.md
@@ -1,0 +1,3 @@
+# Coding standards
+
+Follow PEP 8. Every public function needs a docstring and type hints.

--- a/tests/fixtures/sample-windsurf-setup/.windsurf/rules/security.md
+++ b/tests/fixtures/sample-windsurf-setup/.windsurf/rules/security.md
@@ -1,0 +1,3 @@
+# Security
+
+Never hardcode credentials. Read secrets from environment variables.

--- a/tests/fixtures/sample-windsurf-setup/.windsurfrules
+++ b/tests/fixtures/sample-windsurf-setup/.windsurfrules
@@ -1,0 +1,6 @@
+---
+name: project-rules
+---
+# Project rules
+
+Use PEP 8 for all Python code. Prefer explicit over implicit.

--- a/tests/test_multitool_mcp_discovery.py
+++ b/tests/test_multitool_mcp_discovery.py
@@ -1,0 +1,128 @@
+"""Tests for issue #30 'also needed' items: Copilot instructions and
+Gemini/OpenCode MCP config discovery."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from harness_eval.core.setup import discover_setup
+from harness_eval.core.types import ComponentType
+from harness_eval.inspection.engine import inspect_setup
+
+
+def _diag_ids(setup, config):
+    results = inspect_setup(setup, config)
+    return [(d.rule_id, d.message) for r in results for d in r.diagnostics]
+
+
+class TestCopilotInstructions:
+    def test_discovered_as_claude_md(self, tmp_path: Path) -> None:
+        gh = tmp_path / ".github"
+        gh.mkdir()
+        (gh / "copilot-instructions.md").write_text(
+            "# Copilot instructions\n\nUse PEP 8. Prefer small functions.\n", encoding="utf-8"
+        )
+        setup = discover_setup("copilot", str(tmp_path))
+        claude_md = setup.by_type(ComponentType.CLAUDE_MD)
+        names = {c.name for c in claude_md}
+        assert "copilot-instructions" in names
+        comp = next(c for c in claude_md if c.name == "copilot-instructions")
+        assert comp.source_tool == "copilot"
+        assert "Copilot" in setup.detected_tools
+
+    def test_no_claude_only_rules_fire(self, tmp_path: Path) -> None:
+        gh = tmp_path / ".github"
+        gh.mkdir()
+        (gh / "copilot-instructions.md").write_text("# Instructions\n\nBe concise.\n", "utf-8")
+        setup = discover_setup("copilot", str(tmp_path))
+        ids = [rid for rid, _ in _diag_ids(setup, {"claude-md/exists": "warning"})]
+        assert "claude-md/exists" not in ids
+
+
+class TestGeminiMcp:
+    def _write(self, tmp_path: Path, obj: dict) -> None:
+        gd = tmp_path / ".gemini"
+        gd.mkdir()
+        (gd / "settings.json").write_text(json.dumps(obj), encoding="utf-8")
+
+    def test_settings_with_mcpservers_discovered(self, tmp_path: Path) -> None:
+        self._write(
+            tmp_path,
+            {"mcpServers": {"fs": {"command": "npx", "args": ["-y", "server-fs"]}}},
+        )
+        setup = discover_setup("gemini", str(tmp_path))
+        mcp = setup.by_type(ComponentType.MCP_CONFIG)
+        assert len(mcp) == 1
+        assert mcp[0].source_tool == "gemini"
+        # valid-config must NOT report missing servers for a real MCP config
+        msgs = [m for rid, m in _diag_ids(setup, {"mcp/valid-config": "warning"})]
+        assert not any("no 'mcpServers'" in m for m in msgs)
+
+    def test_settings_without_mcpservers_not_discovered(self, tmp_path: Path) -> None:
+        self._write(tmp_path, {"theme": "dark", "vimMode": True})
+        setup = discover_setup("gemini", str(tmp_path))
+        assert setup.by_type(ComponentType.MCP_CONFIG) == []
+
+    def test_global_settings_via_user_config(self, tmp_path: Path) -> None:
+        home = tmp_path / "home-gemini"
+        home.mkdir()
+        (home / "settings.json").write_text(
+            json.dumps({"mcpServers": {"fs": {"command": "npx", "args": ["-y", "srv"]}}}),
+            encoding="utf-8",
+        )
+        proj = tmp_path / "proj"
+        proj.mkdir()
+        setup = discover_setup("gemini", str(proj), user_config_dir=str(home))
+        mcp = setup.by_type(ComponentType.MCP_CONFIG)
+        assert len(mcp) == 1
+        assert mcp[0].source_tool == "gemini"
+        assert mcp[0].name == "~/.gemini/settings.json"
+
+
+class TestOpenCodeMcp:
+    def _write(self, tmp_path: Path, obj: dict) -> None:
+        (tmp_path / "opencode.json").write_text(json.dumps(obj), encoding="utf-8")
+
+    def test_opencode_mcp_key_discovered(self, tmp_path: Path) -> None:
+        self._write(
+            tmp_path,
+            {
+                "$schema": "https://opencode.ai/config.json",
+                "mcp": {
+                    "local-fs": {
+                        "type": "local",
+                        "command": ["bun", "x", "mcp-fs"],
+                        "enabled": True,
+                    }
+                },
+            },
+        )
+        setup = discover_setup("opencode", str(tmp_path))
+        mcp = setup.by_type(ComponentType.MCP_CONFIG)
+        assert len(mcp) == 1
+        assert mcp[0].source_tool == "opencode"
+        # The MCP rules must understand the 'mcp' key: no false missing-servers,
+        # and a list-form command must not trigger the no-transport error.
+        msgs = [m for rid, m in _diag_ids(setup, {"mcp/valid-config": "warning"})]
+        assert not any("no 'mcpServers'" in m for m in msgs)
+        assert not any("no 'command'" in m for m in msgs)
+
+    def test_opencode_remote_server_url_seen(self, tmp_path: Path) -> None:
+        self._write(
+            tmp_path,
+            {
+                "mcp": {
+                    "remote": {"type": "remote", "url": "http://127.0.0.1:8080", "enabled": True}
+                }
+            },
+        )
+        setup = discover_setup("opencode", str(tmp_path))
+        # suspicious-endpoint reads url via the shared extractor -> should flag localhost
+        ids = [rid for rid, _ in _diag_ids(setup, {"mcp/suspicious-endpoint": "warning"})]
+        assert "mcp/suspicious-endpoint" in ids
+
+    def test_opencode_without_mcp_key_not_discovered(self, tmp_path: Path) -> None:
+        self._write(tmp_path, {"theme": "opencode", "model": "anthropic/claude"})
+        setup = discover_setup("opencode", str(tmp_path))
+        assert setup.by_type(ComponentType.MCP_CONFIG) == []

--- a/tests/test_windsurf_cline_discovery.py
+++ b/tests/test_windsurf_cline_discovery.py
@@ -1,0 +1,96 @@
+"""Tests for Windsurf and Cline file discovery."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from harness_eval.core.setup import discover_setup
+from harness_eval.core.types import ComponentType
+from harness_eval.inspection.engine import inspect_setup
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures"
+
+
+class TestWindsurfDiscovery:
+    def test_discover_windsurfrules(self) -> None:
+        setup = discover_setup(name="windsurf", path=str(FIXTURES_DIR / "sample-windsurf-setup"))
+        names = {c.name for c in setup.by_type(ComponentType.CLAUDE_MD)}
+        assert ".windsurfrules" in names
+
+    def test_discover_rules_dir(self) -> None:
+        setup = discover_setup(name="windsurf", path=str(FIXTURES_DIR / "sample-windsurf-setup"))
+        names = {c.name for c in setup.by_type(ComponentType.CLAUDE_MD)}
+        assert "coding-standards" in names
+        assert "security" in names
+
+    def test_detect_windsurf(self) -> None:
+        setup = discover_setup(name="windsurf", path=str(FIXTURES_DIR / "sample-windsurf-setup"))
+        assert "Windsurf" in setup.detected_tools
+        assert "Claude Code" not in setup.detected_tools
+
+    def test_source_tool_attribution(self) -> None:
+        setup = discover_setup(name="windsurf", path=str(FIXTURES_DIR / "sample-windsurf-setup"))
+        windsurf = [c for c in setup.components if ".windsurf" in c.path]
+        assert windsurf
+        for comp in windsurf:
+            assert comp.source_tool == "windsurf"
+
+    def test_content_and_frontmatter_parsed(self) -> None:
+        setup = discover_setup(name="windsurf", path=str(FIXTURES_DIR / "sample-windsurf-setup"))
+        claude_md = setup.by_type(ComponentType.CLAUDE_MD)
+        rules = next(c for c in claude_md if c.name == ".windsurfrules")
+        assert rules.frontmatter is not None
+        assert rules.frontmatter.get("name") == "project-rules"
+        coding = next(c for c in claude_md if c.name == "coding-standards")
+        assert "PEP 8" in coding.content
+        assert coding.token_count > 0
+
+    def test_no_detection_when_absent(self, tmp_path: Path) -> None:
+        setup = discover_setup(name="empty", path=str(tmp_path))
+        assert "Windsurf" not in setup.detected_tools
+
+    def test_inspect_runs(self) -> None:
+        setup = discover_setup(name="windsurf", path=str(FIXTURES_DIR / "sample-windsurf-setup"))
+        results = inspect_setup(setup)
+        assert len(results) > 0
+        assert "claude_md" in {r.target_type for r in results}
+
+
+class TestClineDirectoryForm:
+    def test_discover_rules_dir(self) -> None:
+        setup = discover_setup(name="cline", path=str(FIXTURES_DIR / "sample-cline-setup"))
+        names = {c.name for c in setup.by_type(ComponentType.CLAUDE_MD)}
+        assert "coding" in names
+        assert "security" in names
+
+    def test_detect_cline(self) -> None:
+        setup = discover_setup(name="cline", path=str(FIXTURES_DIR / "sample-cline-setup"))
+        assert "Cline" in setup.detected_tools
+
+    def test_source_tool_attribution(self) -> None:
+        setup = discover_setup(name="cline", path=str(FIXTURES_DIR / "sample-cline-setup"))
+        cline = [c for c in setup.components if ".clinerules" in c.path]
+        assert cline
+        for comp in cline:
+            assert comp.source_tool == "cline"
+
+
+class TestClineSingleFileForm:
+    def test_discover_single_file(self, tmp_path: Path) -> None:
+        (tmp_path / ".clinerules").write_text(
+            "# Rules\n\nUse PEP 8. Never hardcode credentials.\n", encoding="utf-8"
+        )
+        setup = discover_setup(name="cline-file", path=str(tmp_path))
+        claude_md = setup.by_type(ComponentType.CLAUDE_MD)
+        names = {c.name for c in claude_md}
+        assert ".clinerules" in names
+        assert "Cline" in setup.detected_tools
+        assert all(c.source_tool == "cline" for c in claude_md)
+
+
+class TestDeduplication:
+    def test_no_duplicate_components(self) -> None:
+        for fixture in ("sample-windsurf-setup", "sample-cline-setup"):
+            setup = discover_setup(name=fixture, path=str(FIXTURES_DIR / fixture))
+            resolved = [str(Path(c.path).resolve()) for c in setup.components]
+            assert len(resolved) == len(set(resolved))


### PR DESCRIPTION
Closes #30. Adds discovery for the two named tools plus the three "also needed" items, following the existing `ToolDiscoverer` pattern in `core/discoverers/`.

## What's added

**Windsurf** (`WindsurfDiscoverer`)
- `.windsurfrules` and `.windsurf/rules/*.md`, each mapped to a `CLAUDE_MD` component (one per file, matching the Cursor `.cursorrules` / `.cursor/rules/*.mdc` precedent).

**Cline** (`ClineDiscoverer`)
- `.clinerules` as a single markdown file **or** a `.clinerules/` directory of `*.md` files, mapped to `CLAUDE_MD`.

**Copilot**
- `.github/copilot-instructions.md` discovered as `CLAUDE_MD`.

**Gemini CLI**
- MCP config from `settings.json` discovered as `MCP_CONFIG` — both project-level `.gemini/settings.json` and the global `~/.gemini/settings.json` (via `--user-config`, mirroring how the Claude discoverer handles `~/.claude`). Gated on an `mcpServers` key so ordinary settings files aren't misclassified.

**OpenCode**
- `opencode.json` / `opencode.jsonc` discovered as `MCP_CONFIG`, gated on the `mcp` key.
- OpenCode uses an `mcp` key (not `mcpServers`) with list-form commands, so a shared `extract_servers()` helper was added and all four MCP rules (`valid-config`, `no-wildcard-tools`, `duplicate-server`, `suspicious-endpoint`) now read either key. Existing `mcpServers` behavior is unchanged.

Both new discoverers are registered in `core/discoverers/registry.py`; detection, dedup, and recursive scanning use the existing pipeline. No new lint rules — rule count unchanged.

## Tests
- `tests/test_windsurf_cline_discovery.py` — 12 tests.
- `tests/test_multitool_mcp_discovery.py` — 8 tests (Copilot instructions; Gemini project + global MCP; MCP discovered only when the MCP key is present; OpenCode `mcp`/list-command parsed with no false positives; localhost remote still flagged).

## Verification
- `ruff format --check` and `ruff check` — clean
- New tests pass (20); no regressions in the MCP / multi-assistant / cursor / security / cross-component suites
- Dogfood: `harness-eval lint . --fail-on-error` -> exit 0; `harness-eval security . --fail-on-warning` -> SAFE
- README "Supported AI Assistants" table and CHANGELOG updated
