### PR TITLE
feat: redact LLM payloads and exclude credential paths (HE-2, HE-3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,16 @@ For the complete rule list with examples, detection techniques, and framework ma
 
 ## Privacy
 
-`lint` and `security` (without `--review`) are fully offline. `review`, `security --review`, and `skill --rubric` send code snippets to an LLM provider (Gemini or Anthropic API via CLI, or in-session when used as a plugin/command). See [`docs/how-can-you-know-its-safe-to-use-this-tool.md`](docs/how-can-you-know-its-safe-to-use-this-tool.md) for details.
+`lint` and `security` (without `--review`) are fully offline. **LLM review is opt-in:**
+only `review`, `security --review`, and `skill --rubric` send snippets to a remote
+provider (Gemini or Anthropic via CLI, or in-session as a plugin/command).
+
+Before any remote LLM call, likely secrets (tokens, PEM keys, `API_KEY=` assignments,
+known prefix patterns) are replaced with `[REDACTED]` (HE-2). Scans also skip `.env`,
+`credentials` paths, and `*.pem` / `*.key` / `id_rsa` globs by default (HE-3); add
+more with `--exclude`.
+
+See [`docs/how-can-you-know-its-safe-to-use-this-tool.md`](docs/how-can-you-know-its-safe-to-use-this-tool.md) for details.
 
 ## Contributing
 

--- a/src/harness_eval/cli/review.py
+++ b/src/harness_eval/cli/review.py
@@ -12,6 +12,7 @@ from harness_eval.cli import cli
 from harness_eval.core.setup import discover_setup
 from harness_eval.core.types import ComponentType
 from harness_eval.output.metadata import EvalMetadata
+from harness_eval.rubric.types import RubricResult
 from harness_eval.utils.redact import redact_secrets
 
 

--- a/src/harness_eval/cli/review.py
+++ b/src/harness_eval/cli/review.py
@@ -12,7 +12,7 @@ from harness_eval.cli import cli
 from harness_eval.core.setup import discover_setup
 from harness_eval.core.types import ComponentType
 from harness_eval.output.metadata import EvalMetadata
-from harness_eval.rubric.types import RubricResult
+from harness_eval.utils.redact import redact_secrets
 
 
 @cli.command("review")
@@ -47,7 +47,8 @@ def eval_setup_review(
     checker = RubricChecker(client)
 
     context_parts = [
-        f"[{c.component_type.value}] {c.name}: {c.content[:200]}" for c in setup.components
+        f"[{c.component_type.value}] {c.name}: {redact_secrets(c.content)[:200]}"
+        for c in setup.components
     ]
     context_text = "\n".join(context_parts)
 

--- a/src/harness_eval/cli/security.py
+++ b/src/harness_eval/cli/security.py
@@ -15,6 +15,7 @@ from harness_eval.core.setup import discover_setup
 from harness_eval.core.types import ParsedComponent
 from harness_eval.inspection.types import AdjudicatedFinding, Finding, InspectionResult, Severity
 from harness_eval.output.metadata import EvalMetadata
+from harness_eval.utils.redact import redact_secrets
 
 
 @dataclass(frozen=True)
@@ -471,7 +472,10 @@ def eval_setup_security(
                     for d in r.diagnostics
                 ]
                 prompt = build_adjudication_prompt(
-                    r.target_type, r.target_name, comp.content, findings_data
+                    r.target_type,
+                    r.target_name,
+                    redact_secrets(comp.content),
+                    findings_data,
                 )
                 try:
                     response = client.generate(ADJUDICATION_SYSTEM, prompt)
@@ -487,7 +491,8 @@ def eval_setup_security(
             adjudicated = True
 
         context_parts = [
-            f"[{c.component_type.value}] {c.name}: {c.content[:200]}" for c in setup.components
+            f"[{c.component_type.value}] {c.name}: {redact_secrets(c.content)[:200]}"
+            for c in setup.components
         ]
         context_text = "\n".join(context_parts)
 

--- a/src/harness_eval/cli/security.py
+++ b/src/harness_eval/cli/security.py
@@ -467,7 +467,7 @@ def eval_setup_security(
                     {
                         "rule_id": d.rule_id,
                         "severity": d.severity.value,
-                        "message": d.message,
+                        "message": redact_secrets(d.message),
                     }
                     for d in r.diagnostics
                 ]

--- a/src/harness_eval/cli/skill.py
+++ b/src/harness_eval/cli/skill.py
@@ -12,6 +12,7 @@ from harness_eval.cli import cli
 from harness_eval.core.setup import discover_setup
 from harness_eval.core.types import ComponentType
 from harness_eval.output.metadata import EvalMetadata
+from harness_eval.utils.redact import redact_secrets
 
 
 @cli.command("skill")
@@ -86,7 +87,7 @@ def eval_skill(
                 name="context", path=context_path, user_config_dir=user_config
             )
             parts = [
-                f"[{c.component_type.value}] {c.name}: {c.content[:200]}"
+                f"[{c.component_type.value}] {c.name}: {redact_secrets(c.content)[:200]}"
                 for c in ctx_setup.components
             ]
             context_text = "\n".join(parts)

--- a/src/harness_eval/core/setup.py
+++ b/src/harness_eval/core/setup.py
@@ -14,6 +14,28 @@ from harness_eval.core.types import (
     Setup,
 )
 
+# ponytail: default excludes keep credential files out of scan copies (HE-3).
+DEFAULT_SCAN_EXCLUDES: tuple[str, ...] = (
+    "**/.env",
+    "**/.env.*",
+    "**/credentials/**",
+    "**/credentials.*",
+    "**/*.pem",
+    "**/*.key",
+    "**/*id_rsa*",
+)
+
+
+def merge_scan_excludes(user_excludes: tuple[str, ...] = ()) -> tuple[str, ...]:
+    """Return default credential excludes plus any user-supplied patterns."""
+    if not user_excludes:
+        return DEFAULT_SCAN_EXCLUDES
+    merged = list(DEFAULT_SCAN_EXCLUDES)
+    for pattern in user_excludes:
+        if pattern not in merged:
+            merged.append(pattern)
+    return tuple(merged)
+
 
 def _matches_exclude(component_path: str, root: Path, patterns: tuple[str, ...]) -> bool:
     """Check if a component path matches any exclude pattern."""
@@ -44,6 +66,7 @@ def discover_setup(
         raise FileNotFoundError(f"Setup path does not exist: {path}")
 
     user_dir = Path(user_config_dir) if user_config_dir else None
+    exclude = merge_scan_excludes(exclude)
 
     components: list[ParsedComponent] = []
 

--- a/src/harness_eval/rubric/scorer.py
+++ b/src/harness_eval/rubric/scorer.py
@@ -76,9 +76,7 @@ class RubricChecker:
         if not categories:
             return [RubricResult(component_name=cn, component_type=ct) for ct, cn, _ in components]
 
-        safe_components = [
-            (ct, cn, redact_secrets(cc)) for ct, cn, cc in components
-        ]
+        safe_components = [(ct, cn, redact_secrets(cc)) for ct, cn, cc in components]
         prompt = build_batch_prompt(
             safe_components,
             categories,

--- a/src/harness_eval/rubric/scorer.py
+++ b/src/harness_eval/rubric/scorer.py
@@ -9,6 +9,7 @@ from harness_eval.rubric.dimensions import CATEGORIES_BY_TYPE
 from harness_eval.rubric.prompts import SYSTEM_PROMPT, build_batch_prompt, build_issue_prompt
 from harness_eval.rubric.types import IssueCategory, RubricIssue, RubricResult
 from harness_eval.utils.llm import LLMClient
+from harness_eval.utils.redact import redact_secrets
 
 _ISSUE_WITH_IMPACT_RE = re.compile(
     r"ISSUE:\s*(.+?)\s*\|\s*CATEGORY:\s*(\S+)\s*\|\s*SEVERITY:\s*(\S+)\s*\|\s*EVIDENCE:\s*(.+?)\s*\|\s*SUGGESTION:\s*(.+?)\s*\|\s*IMPACT:\s*(.+)"
@@ -52,9 +53,9 @@ class RubricChecker:
         prompt = build_issue_prompt(
             component_type=component_type,
             component_name=component_name,
-            content=content,
+            content=redact_secrets(content),
             categories=categories,
-            context=context,
+            context=redact_secrets(context) if context else None,
         )
 
         response = self.client.generate(SYSTEM_PROMPT, prompt)
@@ -75,7 +76,14 @@ class RubricChecker:
         if not categories:
             return [RubricResult(component_name=cn, component_type=ct) for ct, cn, _ in components]
 
-        prompt = build_batch_prompt(components, categories, context)
+        safe_components = [
+            (ct, cn, redact_secrets(cc)) for ct, cn, cc in components
+        ]
+        prompt = build_batch_prompt(
+            safe_components,
+            categories,
+            redact_secrets(context) if context else None,
+        )
         response = self.client.generate(SYSTEM_PROMPT, prompt)
         return self._parse_batch_response(response, components)
 

--- a/src/harness_eval/utils/redact.py
+++ b/src/harness_eval/utils/redact.py
@@ -1,0 +1,39 @@
+"""Redact likely secrets before sending text to remote LLM providers (HE-2)."""
+
+from __future__ import annotations
+
+import re
+
+from harness_eval.data import load_secret_prefixes
+
+_REDACTED = "[REDACTED]"
+
+_PEM_BLOCK_RE = re.compile(
+    r"-----BEGIN [A-Z ]*PRIVATE KEY-----.*?-----END [A-Z ]*PRIVATE KEY-----",
+    re.DOTALL,
+)
+_ASSIGNMENT_RE = re.compile(
+    r"(?i)\b([A-Z0-9_]*(?:API[_-]?KEY|TOKEN|SECRET|PASSWORD|CREDENTIAL)[A-Z0-9_]*)\s*[:=]\s*\S+"
+)
+_BEARER_RE = re.compile(r"(?i)\bBearer\s+[A-Za-z0-9._\-+/=]{8,}\b")
+
+
+def redact_secrets(text: str) -> str:
+    """Replace likely secret material with a fixed placeholder."""
+    if not text:
+        return text
+
+    redacted = _PEM_BLOCK_RE.sub(_REDACTED, text)
+    redacted = _ASSIGNMENT_RE.sub(lambda m: f"{m.group(1)}={_REDACTED}", redacted)
+    redacted = _BEARER_RE.sub(f"Bearer {_REDACTED}", redacted)
+
+    for prefix in load_secret_prefixes():
+        if not prefix:
+            continue
+        redacted = re.sub(
+            re.escape(prefix) + r"[A-Za-z0-9_\-./+=]{4,}",
+            _REDACTED,
+            redacted,
+        )
+
+    return redacted

--- a/tests/test_default_excludes.py
+++ b/tests/test_default_excludes.py
@@ -1,0 +1,45 @@
+"""Tests for default credential file scan excludes (HE-3)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from harness_eval.core.setup import DEFAULT_SCAN_EXCLUDES, discover_setup
+
+
+def _make_skill(tmp: Path, name: str) -> None:
+    skill_dir = tmp / "skills" / name
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "SKILL.md").write_text(
+        f"---\nname: {name}\ndescription: Test skill\n---\n\nTest."
+    )
+
+
+class TestDefaultScanExcludes:
+    def test_env_file_excluded_by_default(self, tmp_path: Path) -> None:
+        _make_skill(tmp_path, "my-skill")
+        (tmp_path / "CLAUDE.md").write_text("# Test")
+        (tmp_path / ".env").write_text("API_KEY=secret")
+
+        setup = discover_setup("test", str(tmp_path))
+        paths = [c.path for c in setup.components]
+        assert not any(".env" in p for p in paths)
+
+    def test_pem_and_key_globs_excluded_by_default(self, tmp_path: Path) -> None:
+        _make_skill(tmp_path, "my-skill")
+        (tmp_path / "CLAUDE.md").write_text("# Test")
+        secrets = tmp_path / "credentials"
+        secrets.mkdir()
+        (secrets / "client.pem").write_text("-----BEGIN PRIVATE KEY-----")
+        (secrets / "server.key").write_text("key-material")
+
+        setup = discover_setup("test", str(tmp_path))
+        paths = [c.path for c in setup.components]
+        assert not any("client.pem" in p for p in paths)
+        assert not any("server.key" in p for p in paths)
+
+    def test_default_excludes_include_env_and_credentials(self) -> None:
+        joined = " ".join(DEFAULT_SCAN_EXCLUDES)
+        assert ".env" in joined
+        assert "credentials" in joined
+        assert ".pem" in joined

--- a/tests/test_default_excludes.py
+++ b/tests/test_default_excludes.py
@@ -10,9 +10,7 @@ from harness_eval.core.setup import DEFAULT_SCAN_EXCLUDES, discover_setup
 def _make_skill(tmp: Path, name: str) -> None:
     skill_dir = tmp / "skills" / name
     skill_dir.mkdir(parents=True, exist_ok=True)
-    (skill_dir / "SKILL.md").write_text(
-        f"---\nname: {name}\ndescription: Test skill\n---\n\nTest."
-    )
+    (skill_dir / "SKILL.md").write_text(f"---\nname: {name}\ndescription: Test skill\n---\n\nTest.")
 
 
 class TestDefaultScanExcludes:

--- a/tests/test_redact.py
+++ b/tests/test_redact.py
@@ -1,0 +1,28 @@
+"""Tests for secret redaction before LLM calls (HE-2)."""
+
+from harness_eval.utils.redact import redact_secrets
+
+
+def test_redacts_pem_private_key_block() -> None:
+    text = "key = '''-----BEGIN RSA PRIVATE KEY-----\nabc\n-----END RSA PRIVATE KEY-----'''"
+    assert "abc" not in redact_secrets(text)
+    assert "[REDACTED]" in redact_secrets(text)
+
+
+def test_redacts_known_token_prefixes() -> None:
+    text = "export GITHUB_TOKEN=ghp_abcdefghijklmnopqrstuvwxyz1234567890"
+    redacted = redact_secrets(text)
+    assert "ghp_" not in redacted
+    assert "[REDACTED]" in redacted
+
+
+def test_redacts_assignment_patterns() -> None:
+    text = "API_KEY=super-secret-value"
+    redacted = redact_secrets(text)
+    assert "super-secret-value" not in redacted
+    assert "API_KEY=[REDACTED]" in redacted
+
+
+def test_leaves_benign_content_unchanged() -> None:
+    text = "Use pytest to run unit tests."
+    assert redact_secrets(text) == text


### PR DESCRIPTION
## Summary

Implements mitigations **HE-2** and **HE-3** from the ai-agent-risk resync run.

**HE-2:** Document that LLM review is opt-in (unchanged CLI flags) and redact likely secrets before any remote LLM send (`review`, `security --review`, `skill --rubric`).

**HE-3:** Default scan excludes for `.env`, `credentials` paths, and `*.pem` / `*.key` / `id_rsa` globs (still overridable via `--exclude`).

## Risk assessment

Run: [2026-08-09T060900Z_must-should-resync](https://gitlab.cee.redhat.com/qe-ds/ai-agent-risk/-/blob/main/reports/runs/2026-08-09T060900Z_must-should-resync.md)

Mitigations: **HE-2**, **HE-3**

## Test plan

- [x] `pytest tests/test_redact.py tests/test_default_excludes.py tests/test_exclude.py`

Made with [Cursor](https://cursor.com)