### PR TITLE
feat: CI hygiene - mypy, rules-reference completeness, changelog check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,10 @@ jobs:
       - name: Ruff format
         run: uv run ruff format --check src/ tests/
 
+      - name: Mypy type check
+        continue-on-error: true
+        run: uv run mypy src/ --ignore-missing-imports
+
   test:
     runs-on: ubuntu-latest
     strategy:
@@ -56,6 +60,29 @@ jobs:
 
       - name: Run tests with coverage
         run: uv run pytest -v --cov=src --cov-report=term-missing --cov-fail-under=70
+
+  changelog:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check CHANGELOG.md updated
+        run: |
+          TITLE="${{ github.event.pull_request.title }}"
+          if echo "$TITLE" | grep -qiE '^(feat|fix|refactor|perf|security)'; then
+            if git diff --name-only origin/main...HEAD | grep -q '^CHANGELOG.md$'; then
+              echo "CHANGELOG.md updated."
+            else
+              echo "::error::PR title starts with feat/fix/refactor/perf/security but CHANGELOG.md was not modified."
+              echo "Add an entry under [Unreleased] in CHANGELOG.md."
+              exit 1
+            fi
+          else
+            echo "Skipping: PR title does not indicate a feature/fix commit."
+          fi
 
   dogfood:
     runs-on: ubuntu-latest

--- a/docs/rules-reference.md
+++ b/docs/rules-reference.md
@@ -129,6 +129,9 @@ These rules run against MCP server configuration files. Applies to: CC, CU.
 | `mcp/duplicate-server` | content | Flags MCP servers that appear more than once (same name or same URL). Duplicates cause confusion about which instance to use. | Two entries both named `github` with different configs | Key deduplication |
 | `mcp/suspicious-endpoint` | security | Flags MCP servers pointing to localhost or private IP addresses. These often indicate development configs accidentally left in a shared project. | `http://192.168.1.1:8080` or `http://localhost:3000` as an MCP server URL | Pattern matching (IP ranges) |
 | `mcp/no-wildcard-tools` | security | Flags MCP servers that expose all their tools without restriction. Least privilege means only exposing the tools the project actually needs. | An MCP server with no `allowedTools` filter, granting access to every tool it offers | Config field check |
+| `mcp/no-plaintext-secrets` | security | Flags MCP server configs that contain plaintext secrets (API keys, tokens, passwords) in `env` or `args`. Secrets should come from environment variables or secret managers, not be hardcoded. | `"env": {"API_KEY": "sk-abc123..."}` in `.mcp.json` | Regex pattern matching (known secret prefixes) |
+| `mcp/unpinned-package` | security | Flags MCP servers installed via `npx -y` or `@latest` without version pinning. Unpinned packages pull whatever version is current, which could include malicious updates. | `"command": "npx -y @modelcontextprotocol/server-github"` without a version pin | Package reference parsing |
+| `mcp/auto-approve-risk` | security | Flags MCP server configs that use `autoApprove` to bypass the user confirmation prompt for specific tools. Auto-approved tools execute without human review. | `"autoApprove": ["read_file", "write_file"]` in an MCP server config | Config field check |
 
 ## Hooks (.claude/settings.json hooks, .cursor/hooks.json)
 

--- a/tests/test_doc_counts.py
+++ b/tests/test_doc_counts.py
@@ -71,6 +71,23 @@ class TestRuleCountDrift:
                 )
 
 
+class TestRulesReferenceCompleteness:
+    def test_every_rule_is_documented(self) -> None:
+        rules_ref = ROOT / "docs" / "rules-reference.md"
+        if not rules_ref.exists():
+            return
+        content = rules_ref.read_text()
+        all_rules = get_all_rules()
+        missing = []
+        for rule in all_rules:
+            if rule.meta.id not in content:
+                missing.append(rule.meta.id)
+        assert missing == [], (
+            f"{len(missing)} rules missing from docs/rules-reference.md: "
+            + ", ".join(sorted(missing))
+        )
+
+
 class TestCommandSurfaceSync:
     def test_claude_and_cursor_commands_have_same_names(self) -> None:
         claude_dir = ROOT / "commands"


### PR DESCRIPTION
## Summary

Three CI hygiene improvements that would have prevented issues we hit this session.

- **#54 Mypy in CI**: Added `uv run mypy src/ --ignore-missing-imports` to the lint job. Set to `continue-on-error: true` until the existing 95 type errors are fixed. Surfaces type issues in CI output without blocking merges.
- **#59 Rules-reference completeness test**: New `TestRulesReferenceCompleteness` that verifies every registered rule ID appears in `docs/rules-reference.md`. Found and added 3 missing MCP rules (`no-plaintext-secrets`, `unpinned-package`, `auto-approve-risk`).
- **#62 Changelog CI check**: New `changelog` job that fails PRs titled `feat:/fix:/refactor:/perf:/security:` when `CHANGELOG.md` is not modified. Skips for docs/chore/ci PRs.

Closes #54, closes #59, closes #62.

## Test plan

- [x] 824 tests passed, 0 failures
- [x] `ruff check` and `ruff format` clean
- [x] Rules-reference completeness test passes (was failing before adding 3 MCP rules)
- [x] Doc count drift test passes