### PR TITLE
feat: fix suggestions, command generation, shared output, test coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- **Fix suggestions for all 92 rules.** Every finding now includes an actionable "Fix:" line in terminal output and a `suggestion` field in JSON output. Suggestions are set via `default_suggestion` on `RuleMeta` and can be overridden per-finding.
+- `scripts/sync_commands.py`: generates Claude Code `commands/` stubs from `.cursor/commands/` source. Run with `--check` in CI to prevent drift.
+- Tests for `utils/llm.py` (LLM client abstraction) and suppression edge cases (22 new tests)
 - Mypy type checking step in CI lint job (continue-on-error until existing errors are fixed)
 - `TestRulesReferenceCompleteness` test verifying all registered rules appear in `docs/rules-reference.md`
 - Changelog enforcement CI job that fails PRs titled `feat:/fix:/refactor:/perf:/security:` when CHANGELOG.md is not modified

--- a/commands/eval-skill.md
+++ b/commands/eval-skill.md
@@ -1,12 +1,12 @@
 ---
-description: "Deep-evaluate a single skill with static analysis and qualitative review, both individually and in context of the full setup. Check if a skill is worth keeping, well-built, or redundant."
+description: "Deep-evaluate a single skill with static analysis and qualitative review, both individually and in context of the full setup"
 ---
 
 # Eval Skill
 
 Use the Skill tool to invoke `eval-skill` explicitly.
 
-Pass through any arguments from $ARGUMENTS (e.g., a skill name or path to evaluate).
+Pass through any arguments from $ARGUMENTS (e.g., a specific path to evaluate).
 
 If the Skill tool is not available or the skill is not found, tell the user:
 - Check that `skills/eval-skill/SKILL.md` exists in the workspace

--- a/commands/lint.md
+++ b/commands/lint.md
@@ -1,5 +1,5 @@
 ---
-description: "Run deterministic static analysis on the full agent setup (CLAUDE.md, skills, commands, hooks, agents, MCP configs). 92 rules + system-level analysis. No LLM, fast, CI-suitable."
+description: "Run 92 deterministic rules + system-level analysis on the agent setup. No LLM. Fast, reproducible, CI-suitable"
 ---
 
 # Eval Setup Lint

--- a/commands/review.md
+++ b/commands/review.md
@@ -1,5 +1,5 @@
 ---
-description: "Full qualitative review of the agent setup. Per-component rubrics, 21 cross-type checks, KEEP/REVIEW/REMOVE verdicts. Use for deep review, redundancy check, or quality assessment."
+description: "Full qualitative review of the agent setup. Read every file, evaluate quality, redundancy, and optimization opportunities. Produce KEEP/REVIEW/REMOVE verdicts per component"
 ---
 
 # Eval Setup Review

--- a/commands/security.md
+++ b/commands/security.md
@@ -1,5 +1,5 @@
 ---
-description: "Deep security audit of the agent setup. Deterministic security rules (prompt injection, credential access, exfiltration, taint tracking, YARA, CVE) plus LLM semantic review."
+description: "Deep security audit of the agent setup. Combines deterministic scanning with semantic security review"
 ---
 
 # Eval Setup Security

--- a/scripts/sync_commands.py
+++ b/scripts/sync_commands.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.11"
+# ///
+"""Generate Claude Code commands/ from .cursor/commands/ source files.
+
+Claude Code commands delegate to skills via the Skill tool.
+Cursor commands contain full instructions (no Skill tool available).
+This script generates the Claude Code stubs from the Cursor source,
+extracting the description from the first paragraph.
+
+Usage:
+    uv run scripts/sync_commands.py          # generate
+    uv run scripts/sync_commands.py --check  # verify in sync (CI)
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+CURSOR_DIR = ROOT / ".cursor" / "commands"
+CLAUDE_DIR = ROOT / "commands"
+
+STUB_TEMPLATE = """\
+---
+description: "{description}"
+---
+
+# {title}
+
+Use the Skill tool to invoke `{skill_name}` explicitly.
+
+Pass through any arguments from $ARGUMENTS (e.g., a specific path to evaluate).
+
+If the Skill tool is not available or the skill is not found, tell the user:
+- Check that `skills/{skill_name}/SKILL.md` exists in the workspace
+- If not, reinstall the harness-eval plugin
+"""
+
+SKILL_NAME_MAP = {
+    "lint": "lint",
+    "review": "review",
+    "security": "security",
+    "eval-skill": "eval-skill",
+}
+
+
+def extract_description(content: str) -> str:
+    lines = content.strip().split("\n")
+    for line in lines:
+        stripped = line.strip()
+        if stripped and not stripped.startswith("#") and not stripped.startswith("---"):
+            return stripped.rstrip(".")
+    return ""
+
+
+def extract_title(content: str) -> str:
+    for line in content.split("\n"):
+        if line.startswith("# "):
+            return line[2:].strip()
+    return ""
+
+
+def generate_stub(cursor_content: str, cmd_name: str) -> str:
+    title = extract_title(cursor_content)
+    description = extract_description(cursor_content)
+    skill_name = SKILL_NAME_MAP.get(cmd_name, cmd_name)
+
+    desc_escaped = description.replace('"', '\\"')
+    return STUB_TEMPLATE.format(
+        description=desc_escaped,
+        title=title,
+        skill_name=skill_name,
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--check", action="store_true", help="Check if commands are in sync (exit 1 if not)"
+    )
+    args = parser.parse_args()
+
+    if not CURSOR_DIR.exists():
+        print(f"Source directory not found: {CURSOR_DIR}", file=sys.stderr)
+        sys.exit(1)
+
+    CLAUDE_DIR.mkdir(parents=True, exist_ok=True)
+
+    cursor_files = sorted(CURSOR_DIR.glob("*.md"))
+    if not cursor_files:
+        print("No .md files found in .cursor/commands/", file=sys.stderr)
+        sys.exit(1)
+
+    out_of_sync = []
+    for cursor_file in cursor_files:
+        cmd_name = cursor_file.stem
+        cursor_content = cursor_file.read_text()
+        stub = generate_stub(cursor_content, cmd_name)
+        claude_file = CLAUDE_DIR / cursor_file.name
+
+        if args.check:
+            if not claude_file.exists():
+                out_of_sync.append(f"  missing: {claude_file.relative_to(ROOT)}")
+            elif claude_file.read_text() != stub:
+                out_of_sync.append(f"  stale: {claude_file.relative_to(ROOT)}")
+        else:
+            claude_file.write_text(stub)
+            print(f"  generated: {claude_file.relative_to(ROOT)}")
+
+    if args.check and out_of_sync:
+        print("Commands out of sync with .cursor/commands/ source:")
+        for line in out_of_sync:
+            print(line)
+        print("\nRun: uv run scripts/sync_commands.py")
+        sys.exit(1)
+    elif args.check:
+        print("Commands are in sync.")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/harness_eval/inspection/engine.py
+++ b/src/harness_eval/inspection/engine.py
@@ -104,6 +104,7 @@ def _make_report_fn(
     findings: list[Finding],
     suppression_counter: list[int],
     explicitly_configured: bool = False,
+    default_suggestion: str | None = None,
 ) -> Callable[[ReportDescriptor], None]:
     """Build a report callback for a single rule.
 
@@ -132,7 +133,7 @@ def _make_report_fn(
                 location=loc,
                 category=category,
                 fix=descriptor.fix if fixable else None,
-                suggestion=descriptor.suggestion,
+                suggestion=descriptor.suggestion or default_suggestion,
             )
         )
 
@@ -235,6 +236,7 @@ def _run_rules(
                 findings,
                 suppression_counter,
                 explicitly_configured,
+                rule.meta.default_suggestion,
             ),
             severity=severity,
             options=options,

--- a/src/harness_eval/inspection/rules/agents/constraint_body_match.py
+++ b/src/harness_eval/inspection/rules/agents/constraint_body_match.py
@@ -68,6 +68,7 @@ class ConstraintBodyMatch:
             "unmatched_constraint": "Body states '{{constraint}}' but no matching disallowedTools entry found — constraint relies on agent compliance, not enforcement",
         },
         target_type=ComponentType.AGENT,
+        default_suggestion="Update the agent body to match its declared constraints.",
     )
 
     def create(self, context: RuleContext) -> None:

--- a/src/harness_eval/inspection/rules/agents/data_exfiltration.py
+++ b/src/harness_eval/inspection/rules/agents/data_exfiltration.py
@@ -27,6 +27,7 @@ class AgentDataExfiltration:
         },
         target_type=ComponentType.AGENT,
         frameworks={"owasp_llm": "LLM06", "owasp_agentic": "AG04"},
+        default_suggestion="Remove the network call or credential access from the agent definition.",
     )
 
     def create(self, context: RuleContext) -> None:

--- a/src/harness_eval/inspection/rules/agents/description_required.py
+++ b/src/harness_eval/inspection/rules/agents/description_required.py
@@ -23,6 +23,7 @@ class AgentDescriptionRequired:
             "empty": "Field 'description' must not be empty",
         },
         target_type=ComponentType.AGENT,
+        default_suggestion="Add a 'description' field to the agent frontmatter.",
     )
 
     def create(self, context: RuleContext) -> None:

--- a/src/harness_eval/inspection/rules/agents/disallowed_tools_parseable.py
+++ b/src/harness_eval/inspection/rules/agents/disallowed_tools_parseable.py
@@ -26,6 +26,7 @@ class DisallowedToolsParseable:
             "unparseable": "disallowedTools entry '{{entry}}' does not match expected format: ToolName or ToolName(pattern)",
         },
         target_type=ComponentType.AGENT,
+        default_suggestion="Fix the disallowedTools list to use valid tool name patterns.",
     )
 
     def create(self, context: RuleContext) -> None:

--- a/src/harness_eval/inspection/rules/agents/excessive_permissions.py
+++ b/src/harness_eval/inspection/rules/agents/excessive_permissions.py
@@ -28,6 +28,7 @@ class AgentExcessivePermissions:
         },
         target_type=ComponentType.AGENT,
         frameworks={"owasp_agentic": "ASI02"},
+        default_suggestion="Add allowedTools or disallowedTools to restrict tool access.",
     )
 
     def create(self, context: RuleContext) -> None:

--- a/src/harness_eval/inspection/rules/agents/memory_write_unscoped.py
+++ b/src/harness_eval/inspection/rules/agents/memory_write_unscoped.py
@@ -37,6 +37,7 @@ class AgentMemoryWriteUnscoped:
         },
         target_type=ComponentType.AGENT,
         frameworks={"owasp_agentic": "ASI06"},
+        default_suggestion="Scope memory writes to a specific namespace or session.",
     )
 
     def create(self, context: RuleContext) -> None:

--- a/src/harness_eval/inspection/rules/agents/model_specified.py
+++ b/src/harness_eval/inspection/rules/agents/model_specified.py
@@ -26,6 +26,7 @@ class AgentModelSpecified:
             ),
         },
         target_type=ComponentType.AGENT,
+        default_suggestion="Add 'model: inherit' or a specific model to the agent definition.",
     )
 
     def create(self, context: RuleContext) -> None:

--- a/src/harness_eval/inspection/rules/agents/no_credential_access.py
+++ b/src/harness_eval/inspection/rules/agents/no_credential_access.py
@@ -32,6 +32,7 @@ class AgentNoCredentialAccess:
         },
         target_type=ComponentType.AGENT,
         frameworks={"owasp_llm": "LLM06", "owasp_agentic": "AG05"},
+        default_suggestion="Remove direct credential access from the agent instructions.",
     )
 
     def create(self, context: RuleContext) -> None:

--- a/src/harness_eval/inspection/rules/agents/no_prompt_injection.py
+++ b/src/harness_eval/inspection/rules/agents/no_prompt_injection.py
@@ -28,6 +28,7 @@ class AgentNoPromptInjection:
         },
         target_type=ComponentType.AGENT,
         frameworks={"owasp_llm": "LLM01", "mitre_atlas": "AML.T0051"},
+        default_suggestion="Remove or rephrase the flagged text.",
     )
 
     def create(self, context: RuleContext) -> None:

--- a/src/harness_eval/inspection/rules/agents/obfuscation_detection.py
+++ b/src/harness_eval/inspection/rules/agents/obfuscation_detection.py
@@ -27,6 +27,7 @@ class AgentObfuscationDetection:
         },
         target_type=ComponentType.AGENT,
         frameworks={"owasp_llm": "LLM02", "mitre_atlas": "AML.T0054"},
+        default_suggestion="Replace obfuscated content with plain text.",
     )
 
     def create(self, context: RuleContext) -> None:

--- a/src/harness_eval/inspection/rules/agents/referenced_skills_exist.py
+++ b/src/harness_eval/inspection/rules/agents/referenced_skills_exist.py
@@ -22,6 +22,7 @@ class ReferencedSkillsExist:
             "missing_skill": "Agent references skill '{{skill}}' but no SKILL.md found for it",
         },
         target_type=ComponentType.AGENT,
+        default_suggestion="Create the missing skill or fix the reference.",
     )
 
     def create(self, context: RuleContext) -> None:

--- a/src/harness_eval/inspection/rules/agents/reverse_shell_detection.py
+++ b/src/harness_eval/inspection/rules/agents/reverse_shell_detection.py
@@ -29,6 +29,7 @@ class AgentReverseShellDetection:
         },
         target_type=ComponentType.AGENT,
         frameworks={"owasp_agentic": "AG04", "mitre_atlas": "AML.T0054"},
+        default_suggestion="Remove the reverse shell pattern from the agent definition.",
     )
 
     def create(self, context: RuleContext) -> None:

--- a/src/harness_eval/inspection/rules/agents/unbounded_delegation.py
+++ b/src/harness_eval/inspection/rules/agents/unbounded_delegation.py
@@ -37,6 +37,7 @@ class AgentUnboundedDelegation:
         },
         target_type=ComponentType.AGENT,
         frameworks={"owasp_agentic": "ASI08"},
+        default_suggestion="Add a recursion depth limit to the delegation chain.",
     )
 
     def create(self, context: RuleContext) -> None:

--- a/src/harness_eval/inspection/rules/claude_md/exists.py
+++ b/src/harness_eval/inspection/rules/claude_md/exists.py
@@ -23,6 +23,7 @@ class ClaudeMdExists:
         },
         target_type=ComponentType.CLAUDE_MD,
         tools=("claude",),
+        default_suggestion="Create a CLAUDE.md with project-specific build, test, and style instructions.",
     )
 
     def create(self, context: RuleContext) -> None:

--- a/src/harness_eval/inspection/rules/claude_md/generic_advice.py
+++ b/src/harness_eval/inspection/rules/claude_md/generic_advice.py
@@ -26,6 +26,7 @@ class ClaudeMdGenericAdvice:
         },
         target_type=ComponentType.CLAUDE_MD,
         tools=("claude",),
+        default_suggestion="Remove the generic instruction or make it project-specific.",
     )
 
     def create(self, context: RuleContext) -> None:

--- a/src/harness_eval/inspection/rules/claude_md/skill_duplication.py
+++ b/src/harness_eval/inspection/rules/claude_md/skill_duplication.py
@@ -26,6 +26,7 @@ class ClaudeMdSkillDuplication:
             "overlap_cursor": "Rules section '{{section}}' has {{pct}}% similarity with skill '{{skill}}' — consider removing the duplicate content from the rule file since the skill loads on demand",
         },
         target_type=ComponentType.CLAUDE_MD,
+        default_suggestion="Remove the duplicated content from CLAUDE.md.",
     )
 
     def create(self, context: RuleContext) -> None:

--- a/src/harness_eval/inspection/rules/commands/allowed_tools_coverage.py
+++ b/src/harness_eval/inspection/rules/commands/allowed_tools_coverage.py
@@ -86,6 +86,7 @@ class CommandAllowedToolsCoverage:
             ),
         },
         target_type=ComponentType.COMMAND,
+        default_suggestion="Update the allowed-tools list to match the tools the command uses.",
     )
 
     def create(self, context: RuleContext) -> None:

--- a/src/harness_eval/inspection/rules/commands/data_exfiltration.py
+++ b/src/harness_eval/inspection/rules/commands/data_exfiltration.py
@@ -27,6 +27,7 @@ class CommandDataExfiltration:
         },
         target_type=ComponentType.COMMAND,
         frameworks={"owasp_llm": "LLM06", "owasp_agentic": "AG04"},
+        default_suggestion="Remove the network call or credential access from the command.",
     )
 
     def create(self, context: RuleContext) -> None:

--- a/src/harness_eval/inspection/rules/commands/description_required.py
+++ b/src/harness_eval/inspection/rules/commands/description_required.py
@@ -23,6 +23,7 @@ class CommandDescriptionRequired:
             "too_vague": "Description '{{desc}}' is too short or vague — should clearly say what the command does",
         },
         target_type=ComponentType.COMMAND,
+        default_suggestion="Add a 'description' field to the command frontmatter.",
     )
 
     def create(self, context: RuleContext) -> None:

--- a/src/harness_eval/inspection/rules/commands/duplicate_detection.py
+++ b/src/harness_eval/inspection/rules/commands/duplicate_detection.py
@@ -27,6 +27,7 @@ class CommandDuplicateDetection:
             "duplicate": "{{similarity}}% similar to command '{{other}}' — consider merging",
         },
         target_type=ComponentType.COMMAND,
+        default_suggestion="Merge near-duplicate commands into one.",
     )
 
     def create(self, context: RuleContext) -> None:

--- a/src/harness_eval/inspection/rules/commands/no_credential_access.py
+++ b/src/harness_eval/inspection/rules/commands/no_credential_access.py
@@ -32,6 +32,7 @@ class CommandNoCredentialAccess:
         },
         target_type=ComponentType.COMMAND,
         frameworks={"owasp_llm": "LLM06", "owasp_agentic": "AG05"},
+        default_suggestion="Remove direct credential access from the command.",
     )
 
     def create(self, context: RuleContext) -> None:

--- a/src/harness_eval/inspection/rules/commands/no_prompt_injection.py
+++ b/src/harness_eval/inspection/rules/commands/no_prompt_injection.py
@@ -28,6 +28,7 @@ class CommandNoPromptInjection:
         },
         target_type=ComponentType.COMMAND,
         frameworks={"owasp_llm": "LLM01", "mitre_atlas": "AML.T0051"},
+        default_suggestion="Remove or rephrase the flagged text.",
     )
 
     def create(self, context: RuleContext) -> None:

--- a/src/harness_eval/inspection/rules/commands/obfuscation_detection.py
+++ b/src/harness_eval/inspection/rules/commands/obfuscation_detection.py
@@ -27,6 +27,7 @@ class CommandObfuscationDetection:
         },
         target_type=ComponentType.COMMAND,
         frameworks={"owasp_llm": "LLM02", "mitre_atlas": "AML.T0054"},
+        default_suggestion="Replace obfuscated content with plain text.",
     )
 
     def create(self, context: RuleContext) -> None:

--- a/src/harness_eval/inspection/rules/commands/references_nonexistent_skill.py
+++ b/src/harness_eval/inspection/rules/commands/references_nonexistent_skill.py
@@ -32,6 +32,7 @@ class CommandReferencesNonexistentSkill:
             "missing_skill": "Command '{{command}}' references skill '{{skill}}' but no SKILL.md found for it",
         },
         target_type=ComponentType.COMMAND,
+        default_suggestion="Create the missing skill or remove the reference.",
     )
 
     def create(self, context: RuleContext) -> None:

--- a/src/harness_eval/inspection/rules/commands/reverse_shell_detection.py
+++ b/src/harness_eval/inspection/rules/commands/reverse_shell_detection.py
@@ -29,6 +29,7 @@ class CommandReverseShellDetection:
         },
         target_type=ComponentType.COMMAND,
         frameworks={"owasp_agentic": "AG04", "mitre_atlas": "AML.T0054"},
+        default_suggestion="Remove the reverse shell pattern from the command.",
     )
 
     def create(self, context: RuleContext) -> None:

--- a/src/harness_eval/inspection/rules/commands/script_exists.py
+++ b/src/harness_eval/inspection/rules/commands/script_exists.py
@@ -25,6 +25,7 @@ class CommandScriptExists:
             "missing_script": "Command references '{{script}}' but this file does not exist in the command directory",
         },
         target_type=ComponentType.COMMAND,
+        default_suggestion="Create the missing script file or fix the reference path.",
     )
 
     def create(self, context: RuleContext) -> None:

--- a/src/harness_eval/inspection/rules/commands/shadows_builtin.py
+++ b/src/harness_eval/inspection/rules/commands/shadows_builtin.py
@@ -26,6 +26,7 @@ class CommandShadowsBuiltin:
         },
         target_type=ComponentType.COMMAND,
         tools=("claude",),
+        default_suggestion="Rename the command to avoid shadowing the built-in.",
     )
 
     def create(self, context: RuleContext) -> None:

--- a/src/harness_eval/inspection/rules/commands/skill_overlap.py
+++ b/src/harness_eval/inspection/rules/commands/skill_overlap.py
@@ -25,6 +25,7 @@ class CommandSkillOverlap:
             "overlap": "Command '{{command}}' has {{pct}}% similarity with skill '{{skill}}' — consider whether both are needed",
         },
         target_type=ComponentType.COMMAND,
+        default_suggestion="Remove the duplicate content or convert the command to invoke the skill.",
     )
 
     def create(self, context: RuleContext) -> None:

--- a/src/harness_eval/inspection/rules/content/allowed_tools_auto_approve.py
+++ b/src/harness_eval/inspection/rules/content/allowed_tools_auto_approve.py
@@ -35,6 +35,7 @@ class AllowedToolsAutoApprove:
                 "writes without user confirmation."
             ),
         },
+        default_suggestion="Remove dangerous tools from the allowed-tools list.",
     )
 
     def create(self, context: RuleContext) -> None:

--- a/src/harness_eval/inspection/rules/content/broken_references.py
+++ b/src/harness_eval/inspection/rules/content/broken_references.py
@@ -105,6 +105,7 @@ class BrokenReferences:
         messages={
             "broken_ref": "Referenced file '{{ref}}' does not exist",
         },
+        default_suggestion="Fix or remove the broken file reference.",
     )
 
     def create(self, context: RuleContext) -> None:

--- a/src/harness_eval/inspection/rules/content/circular_references.py
+++ b/src/harness_eval/inspection/rules/content/circular_references.py
@@ -54,6 +54,7 @@ class CircularReferences:
             "cycle": "Circular reference detected: {{cycle}}",
         },
         target_type=ComponentType.SKILL,
+        default_suggestion="Break the circular reference chain by removing one link.",
     )
 
     def create(self, context: RuleContext) -> None:

--- a/src/harness_eval/inspection/rules/content/description_length.py
+++ b/src/harness_eval/inspection/rules/content/description_length.py
@@ -30,6 +30,7 @@ class DescriptionLength:
                 "is invoked. Keep descriptions concise; move detail to the body."
             ),
         },
+        default_suggestion="Move detail from the description to the body section.",
     )
 
     def create(self, context: RuleContext) -> None:

--- a/src/harness_eval/inspection/rules/content/duplicate_detection.py
+++ b/src/harness_eval/inspection/rules/content/duplicate_detection.py
@@ -25,6 +25,7 @@ class DuplicateDetection:
         messages={
             "duplicate": "{{similarity}}% similar to '{{other}}' — consider merging",
         },
+        default_suggestion="Merge near-duplicate skills into one.",
     )
 
     def create(self, context: RuleContext) -> None:

--- a/src/harness_eval/inspection/rules/content/hardcoded_machine_path.py
+++ b/src/harness_eval/inspection/rules/content/hardcoded_machine_path.py
@@ -63,6 +63,7 @@ class HardcodedMachinePath:
             ),
         },
         target_type=ComponentType.SKILL,
+        default_suggestion="Replace the absolute path with $HOME, a relative path, or an env var.",
     )
 
     def create(self, context: RuleContext) -> None:

--- a/src/harness_eval/inspection/rules/content/mcp_skill_alignment.py
+++ b/src/harness_eval/inspection/rules/content/mcp_skill_alignment.py
@@ -53,6 +53,7 @@ class McpSkillAlignment:
             "mcp_unused": "MCP server '{{server}}' is configured but no skill references its tools",
         },
         target_type=ComponentType.SKILL,
+        default_suggestion="Remove the unused MCP server or add a skill that uses its tools.",
     )
 
     def create(self, context: RuleContext) -> None:

--- a/src/harness_eval/inspection/rules/content/orphan_skills.py
+++ b/src/harness_eval/inspection/rules/content/orphan_skills.py
@@ -64,6 +64,7 @@ class OrphanSkills:
             "orphan": "Skill '{{name}}' is not referenced by any command, CLAUDE.md, or agent",
         },
         target_type=ComponentType.SKILL,
+        default_suggestion="Reference the skill from a command, CLAUDE.md, or agent, or remove it.",
     )
 
     def create(self, context: RuleContext) -> None:

--- a/src/harness_eval/inspection/rules/content/permission_escalation.py
+++ b/src/harness_eval/inspection/rules/content/permission_escalation.py
@@ -27,6 +27,7 @@ class PermissionEscalation:
             ),
         },
         target_type=ComponentType.SKILL,
+        default_suggestion="Add the required tool to the source skill or remove the reference.",
     )
 
     def create(self, context: RuleContext) -> None:

--- a/src/harness_eval/inspection/rules/content/token_budget.py
+++ b/src/harness_eval/inspection/rules/content/token_budget.py
@@ -28,6 +28,7 @@ class TokenBudget:
             "over_budget": "Skill is {{tokens}} tokens — computed budget is {{budget}} ({{context_budget}} context budget / {{concurrent}} concurrent skills, ceiling {{ceiling}})",
             "over_lines": "SKILL.md is {{lines}} lines — Anthropic recommends keeping SKILL.md under 500 lines",
         },
+        default_suggestion="Split the skill into smaller focused skills, or trim low-value content.",
     )
 
     def create(self, context: RuleContext) -> None:

--- a/src/harness_eval/inspection/rules/content/total_context_budget.py
+++ b/src/harness_eval/inspection/rules/content/total_context_budget.py
@@ -28,6 +28,7 @@ class TotalContextBudget:
             ),
         },
         target_type=ComponentType.SKILL,
+        default_suggestion="Remove low-value skills or reduce their token count.",
     )
 
     def create(self, context: RuleContext) -> None:

--- a/src/harness_eval/inspection/rules/content/total_description_budget.py
+++ b/src/harness_eval/inspection/rules/content/total_description_budget.py
@@ -30,6 +30,7 @@ class TotalDescriptionBudget:
                 "session whether invoked or not."
             ),
         },
+        default_suggestion="Shorten skill descriptions to reduce always-loaded token usage.",
     )
 
     def create(self, context: RuleContext) -> None:

--- a/src/harness_eval/inspection/rules/cross/config_instruction_conflict.py
+++ b/src/harness_eval/inspection/rules/cross/config_instruction_conflict.py
@@ -124,6 +124,7 @@ class ConfigInstructionConflict:
             ),
         },
         target_type=ComponentType.SKILL,
+        default_suggestion="Remove the deny entry or update the instruction to use an allowed tool.",
     )
 
     def create(self, context: RuleContext) -> None:

--- a/src/harness_eval/inspection/rules/cross/multi_assistant_drift.py
+++ b/src/harness_eval/inspection/rules/cross/multi_assistant_drift.py
@@ -64,6 +64,7 @@ class MultiAssistantDrift:
             ),
         },
         target_type=ComponentType.SKILL,
+        default_suggestion="Sync the diverged sections between assistant memory files.",
     )
 
     def create(self, context: RuleContext) -> None:

--- a/src/harness_eval/inspection/rules/cross/overpermissive_grants.py
+++ b/src/harness_eval/inspection/rules/cross/overpermissive_grants.py
@@ -79,6 +79,7 @@ class OverpermissiveGrants:
             ),
         },
         target_type=ComponentType.SKILL,
+        default_suggestion="Scope the permission grant to specific commands or paths.",
     )
 
     def create(self, context: RuleContext) -> None:

--- a/src/harness_eval/inspection/rules/frontmatter/description_quality.py
+++ b/src/harness_eval/inspection/rules/frontmatter/description_quality.py
@@ -42,6 +42,7 @@ class DescriptionQuality:
             "too_long": "Description is {{length}} characters — Anthropic's documented limit is 1,024",
             "too_short": "Description is only {{length}} characters — too vague for reliable skill matching",
         },
+        default_suggestion="Rewrite the description to clearly state what the skill does and when to use it.",
     )
 
     def create(self, context: RuleContext) -> None:

--- a/src/harness_eval/inspection/rules/frontmatter/description_required.py
+++ b/src/harness_eval/inspection/rules/frontmatter/description_required.py
@@ -21,6 +21,7 @@ class DescriptionRequired:
             "missing": "Required field 'description' is missing from frontmatter",
             "empty": "Field 'description' must not be empty",
         },
+        default_suggestion="Add a 'description' field to the frontmatter.",
     )
 
     def create(self, context: RuleContext) -> None:

--- a/src/harness_eval/inspection/rules/frontmatter/format_valid.py
+++ b/src/harness_eval/inspection/rules/frontmatter/format_valid.py
@@ -22,6 +22,7 @@ class FormatValid:
             "missing_name": "Field 'name' is missing from frontmatter",
             "name_mismatch": "Frontmatter 'name' ({{fm_name}}) does not match directory name ({{dir_name}})",
         },
+        default_suggestion="Fix the YAML frontmatter syntax errors.",
     )
 
     def create(self, context: RuleContext) -> None:

--- a/src/harness_eval/inspection/rules/hooks/api_key_helper.py
+++ b/src/harness_eval/inspection/rules/hooks/api_key_helper.py
@@ -32,6 +32,7 @@ class HooksApiKeyHelper:
             ),
         },
         target_type=ComponentType.HOOKS,
+        default_suggestion="Move apiKeyHelper to user-scoped settings.",
     )
 
     def create(self, context: RuleContext) -> None:

--- a/src/harness_eval/inspection/rules/hooks/base_url_override.py
+++ b/src/harness_eval/inspection/rules/hooks/base_url_override.py
@@ -44,6 +44,7 @@ class HooksBaseUrlOverride:
             ),
         },
         target_type=ComponentType.HOOKS,
+        default_suggestion="Move this setting to user-scoped config or environment variables.",
     )
 
     def create(self, context: RuleContext) -> None:

--- a/src/harness_eval/inspection/rules/hooks/dangerous_command.py
+++ b/src/harness_eval/inspection/rules/hooks/dangerous_command.py
@@ -32,6 +32,7 @@ class HooksDangerousCommand:
             "dangerous_command": "Hook for event '{{event}}' contains dangerous command: '{{pattern}}'",
         },
         target_type=ComponentType.HOOKS,
+        default_suggestion="Replace the dangerous command with a safer alternative.",
     )
 
     def create(self, context: RuleContext) -> None:

--- a/src/harness_eval/inspection/rules/hooks/env_credential_override.py
+++ b/src/harness_eval/inspection/rules/hooks/env_credential_override.py
@@ -39,6 +39,7 @@ class HooksEnvCredentialOverride:
             ),
         },
         target_type=ComponentType.HOOKS,
+        default_suggestion="Move credential env vars to user-scoped settings or shell profile.",
     )
 
     def create(self, context: RuleContext) -> None:

--- a/src/harness_eval/inspection/rules/hooks/env_leakage.py
+++ b/src/harness_eval/inspection/rules/hooks/env_leakage.py
@@ -36,6 +36,7 @@ class HooksEnvLeakage:
             "env_leakage": "Hook for event '{{event}}' may leak environment variables: '{{pattern}}'",
         },
         target_type=ComponentType.HOOKS,
+        default_suggestion="Remove env var printing or redirect output away from the agent.",
     )
 
     def create(self, context: RuleContext) -> None:

--- a/src/harness_eval/inspection/rules/hooks/matcher_matches_no_tool.py
+++ b/src/harness_eval/inspection/rules/hooks/matcher_matches_no_tool.py
@@ -34,6 +34,7 @@ class HooksMatcherMatchesNoTool:
             ),
         },
         target_type=ComponentType.HOOKS,
+        default_suggestion="Fix the matcher pattern to match a valid tool name.",
     )
 
     def create(self, context: RuleContext) -> None:

--- a/src/harness_eval/inspection/rules/hooks/network_access.py
+++ b/src/harness_eval/inspection/rules/hooks/network_access.py
@@ -30,6 +30,7 @@ class HooksNetworkAccess:
             "network_access": "Hook for event '{{event}}' makes a network call: '{{pattern}}'",
         },
         target_type=ComponentType.HOOKS,
+        default_suggestion="Remove the network call or move it to a user-approved script.",
     )
 
     def create(self, context: RuleContext) -> None:

--- a/src/harness_eval/inspection/rules/hooks/pre_trust_permissions.py
+++ b/src/harness_eval/inspection/rules/hooks/pre_trust_permissions.py
@@ -48,6 +48,7 @@ class HooksPreTrustPermissions:
             ),
         },
         target_type=ComponentType.HOOKS,
+        default_suggestion="Move permissions.allow entries to user-scoped settings.",
     )
 
     def create(self, context: RuleContext) -> None:

--- a/src/harness_eval/inspection/rules/hooks/script_boundary.py
+++ b/src/harness_eval/inspection/rules/hooks/script_boundary.py
@@ -29,6 +29,7 @@ class HooksScriptBoundary:
             ),
         },
         target_type=ComponentType.HOOKS,
+        default_suggestion="Move the hook script inside the project directory.",
     )
 
     def create(self, context: RuleContext) -> None:

--- a/src/harness_eval/inspection/rules/hooks/silent_failure_masking.py
+++ b/src/harness_eval/inspection/rules/hooks/silent_failure_masking.py
@@ -52,6 +52,7 @@ class HooksSilentFailureMasking:
             ),
         },
         target_type=ComponentType.HOOKS,
+        default_suggestion="Remove error suppression or add explicit error handling.",
     )
 
     def create(self, context: RuleContext) -> None:

--- a/src/harness_eval/inspection/rules/hooks/valid_structure.py
+++ b/src/harness_eval/inspection/rules/hooks/valid_structure.py
@@ -35,6 +35,7 @@ class HooksValidStructure:
             "script_missing": "Hook for event '{{event}}' references script '{{script}}' which does not exist",
         },
         target_type=ComponentType.HOOKS,
+        default_suggestion="Add a 'command' field to the hook definition.",
     )
 
     def create(self, context: RuleContext) -> None:

--- a/src/harness_eval/inspection/rules/mcp/auto_approve_risk.py
+++ b/src/harness_eval/inspection/rules/mcp/auto_approve_risk.py
@@ -56,6 +56,7 @@ class McpAutoApproveRisk:
             ),
         },
         target_type=ComponentType.MCP_CONFIG,
+        default_suggestion="Remove write/execute tools from the autoApprove list.",
     )
 
     def create(self, context: RuleContext) -> None:

--- a/src/harness_eval/inspection/rules/mcp/duplicate_server.py
+++ b/src/harness_eval/inspection/rules/mcp/duplicate_server.py
@@ -25,6 +25,7 @@ class McpDuplicateServer:
             "duplicate_url": "Multiple servers share the same URL '{{url}}': {{servers}}",
         },
         target_type=ComponentType.MCP_CONFIG,
+        default_suggestion="Remove the duplicate MCP server entry.",
     )
 
     def create(self, context: RuleContext) -> None:

--- a/src/harness_eval/inspection/rules/mcp/no_plaintext_secrets.py
+++ b/src/harness_eval/inspection/rules/mcp/no_plaintext_secrets.py
@@ -70,6 +70,7 @@ class McpNoPlaintextSecrets:
             ),
         },
         target_type=ComponentType.MCP_CONFIG,
+        default_suggestion="Replace the literal secret with an environment variable reference.",
     )
 
     def create(self, context: RuleContext) -> None:

--- a/src/harness_eval/inspection/rules/mcp/no_wildcard_tools.py
+++ b/src/harness_eval/inspection/rules/mcp/no_wildcard_tools.py
@@ -25,6 +25,7 @@ class McpNoWildcardTools:
             "no_tool_restriction": "Server '{{name}}' has no 'tools' or 'allowedTools' field, exposing all available tools.",
         },
         target_type=ComponentType.MCP_CONFIG,
+        default_suggestion="Add an allowedTools list to restrict exposed tools.",
     )
 
     def create(self, context: RuleContext) -> None:

--- a/src/harness_eval/inspection/rules/mcp/suspicious_endpoint.py
+++ b/src/harness_eval/inspection/rules/mcp/suspicious_endpoint.py
@@ -35,6 +35,7 @@ class McpSuspiciousEndpoint:
             "suspicious_url": "Server '{{name}}' points to local/private address '{{url}}'. This may be a test config left in production.",
         },
         target_type=ComponentType.MCP_CONFIG,
+        default_suggestion="Replace the local address with the production endpoint.",
     )
 
     def create(self, context: RuleContext) -> None:

--- a/src/harness_eval/inspection/rules/mcp/unpinned_package.py
+++ b/src/harness_eval/inspection/rules/mcp/unpinned_package.py
@@ -61,6 +61,7 @@ class McpUnpinnedPackage:
             ),
         },
         target_type=ComponentType.MCP_CONFIG,
+        default_suggestion="Pin the package to an exact version.",
     )
 
     def create(self, context: RuleContext) -> None:

--- a/src/harness_eval/inspection/rules/mcp/valid_config.py
+++ b/src/harness_eval/inspection/rules/mcp/valid_config.py
@@ -31,6 +31,7 @@ class McpValidConfig:
             "env_not_object": "Server '{{name}}': 'env' must be an object, got {{actual_type}}",
         },
         target_type=ComponentType.MCP_CONFIG,
+        default_suggestion="Fix the MCP config file to match the expected JSON structure.",
     )
 
     def create(self, context: RuleContext) -> None:

--- a/src/harness_eval/inspection/rules/quality/example_gap.py
+++ b/src/harness_eval/inspection/rules/quality/example_gap.py
@@ -36,6 +36,7 @@ class ExampleGap:
                 "Adding a code block with a concrete example improves compliance."
             ),
         },
+        default_suggestion="Add a code block with a concrete usage example.",
     )
 
     def create(self, context: RuleContext) -> None:

--- a/src/harness_eval/inspection/rules/quality/imprecise_instruction.py
+++ b/src/harness_eval/inspection/rules/quality/imprecise_instruction.py
@@ -50,6 +50,7 @@ class ImpreciseInstruction:
         messages={
             "imprecise": ("Line {{line}}: '{{match}}' — {{category}}. {{advice}}"),
         },
+        default_suggestion="Replace vague language with specific, actionable wording.",
     )
 
     def create(self, context: RuleContext) -> None:

--- a/src/harness_eval/inspection/rules/quality/negative_only.py
+++ b/src/harness_eval/inspection/rules/quality/negative_only.py
@@ -41,6 +41,7 @@ class NegativeOnly:
                 "Line {{line}}: '{{match}}' states what not to do without saying what to do instead"
             ),
         },
+        default_suggestion="Add what to do instead after each prohibition.",
     )
 
     def create(self, context: RuleContext) -> None:

--- a/src/harness_eval/inspection/rules/quality/redundant_guidance.py
+++ b/src/harness_eval/inspection/rules/quality/redundant_guidance.py
@@ -134,6 +134,7 @@ class RedundantGuidance:
                 "in this project. Remove to avoid contradictions."
             ),
         },
+        default_suggestion="Remove the instruction or add project-specific detail.",
     )
 
     def create(self, context: RuleContext) -> None:

--- a/src/harness_eval/inspection/rules/quality/scope_grab_description.py
+++ b/src/harness_eval/inspection/rules/quality/scope_grab_description.py
@@ -70,6 +70,7 @@ class ScopeGrabDescription:
                 "does, not demand to be chosen for all requests."
             ),
         },
+        default_suggestion="Rewrite the description to state what the skill does, not when to run.",
     )
 
     def create(self, context: RuleContext) -> None:

--- a/src/harness_eval/inspection/rules/quality/scope_overreach.py
+++ b/src/harness_eval/inspection/rules/quality/scope_overreach.py
@@ -38,6 +38,7 @@ class ScopeOverreach:
                 "Skills should be specific about when they apply."
             ),
         },
+        default_suggestion="Narrow the scope claim to specific file types or task contexts.",
     )
 
     def create(self, context: RuleContext) -> None:

--- a/src/harness_eval/inspection/rules/quality/stale_references.py
+++ b/src/harness_eval/inspection/rules/quality/stale_references.py
@@ -95,6 +95,7 @@ class StaleReferences:
         messages={
             "stale": ("Line {{line}}: '{{label}}' is outdated. {{replacement}}"),
         },
+        default_suggestion="Update the outdated reference to its current replacement.",
     )
 
     def create(self, context: RuleContext) -> None:

--- a/src/harness_eval/inspection/rules/quality/trigger_manipulation.py
+++ b/src/harness_eval/inspection/rules/quality/trigger_manipulation.py
@@ -51,6 +51,7 @@ class TriggerManipulation:
                 "where it may not be needed. Let the user decide when to invoke."
             ),
         },
+        default_suggestion="Replace forced-invocation triggers with descriptive when-to-use guidance.",
     )
 
     def create(self, context: RuleContext) -> None:

--- a/src/harness_eval/inspection/rules/quality/unfinished_content.py
+++ b/src/harness_eval/inspection/rules/quality/unfinished_content.py
@@ -65,6 +65,7 @@ class UnfinishedContent:
                 "Add content or remove the heading."
             ),
         },
+        default_suggestion="Complete the placeholder text or remove the empty section.",
     )
 
     def create(self, context: RuleContext) -> None:

--- a/src/harness_eval/inspection/rules/security/ast_behavioral.py
+++ b/src/harness_eval/inspection/rules/security/ast_behavioral.py
@@ -164,6 +164,7 @@ class AstBehavioral:
             "ast_exec_chain": "{{file}}:{{line}} calls {{call}} with a dynamic source (decoded/fetched data), a high-risk execution chain.",
         },
         frameworks={"owasp_agentic": "AG04", "mitre_atlas": "AML.T0054"},
+        default_suggestion="Remove or sandbox the flagged code pattern.",
     )
 
     def create(self, context: RuleContext) -> None:

--- a/src/harness_eval/inspection/rules/security/bash_taint_tracking.py
+++ b/src/harness_eval/inspection/rules/security/bash_taint_tracking.py
@@ -413,6 +413,7 @@ class BashTaintTracking:
             "bash_taint_indirect": "{{file}}: tainted variable '${{var}}' (from line {{source_line}}) flows to {{sink}} (line {{sink_line}}). Possible injection vector.",
         },
         frameworks={"owasp_llm": "LLM06", "owasp_agentic": "AG04"},
+        default_suggestion="Sanitize untrusted input before passing it to shell commands.",
     )
 
     def create(self, context: RuleContext) -> None:

--- a/src/harness_eval/inspection/rules/security/coercive_override.py
+++ b/src/harness_eval/inspection/rules/security/coercive_override.py
@@ -58,6 +58,7 @@ class CoerciveOverride:
             "coercive_in_example": "Line {{line}} contains '{{label}}' in a quote or example (likely safe).",
         },
         frameworks={"owasp_llm": "LLM01", "owasp_agentic": "AG01"},
+        default_suggestion="Remove or rephrase the coercive override pattern.",
     )
 
     def create(self, context: RuleContext) -> None:

--- a/src/harness_eval/inspection/rules/security/cross_component_flow.py
+++ b/src/harness_eval/inspection/rules/security/cross_component_flow.py
@@ -50,6 +50,7 @@ class CrossComponentFlow:
             "owasp_agentic": "AG04",
             "mitre_atlas": "AML.T0054",
         },
+        default_suggestion="Restrict network access in the delegated component or scope credentials.",
     )
 
     def create(self, context: RuleContext) -> None:

--- a/src/harness_eval/inspection/rules/security/cve_lookup.py
+++ b/src/harness_eval/inspection/rules/security/cve_lookup.py
@@ -137,6 +137,7 @@ class CveLookup:
             "cve_no_deps": "No dependency files found in skill directory; CVE lookup skipped.",
         },
         frameworks={"owasp_llm": "LLM05"},
+        default_suggestion="Update the affected package to a patched version.",
     )
 
     def create(self, context: RuleContext) -> None:

--- a/src/harness_eval/inspection/rules/security/data_exfiltration.py
+++ b/src/harness_eval/inspection/rules/security/data_exfiltration.py
@@ -40,6 +40,7 @@ class DataExfiltration:
             "exfil_in_code_block": "Line {{line}} contains '{{label}}' inside a code block — likely documentation, but verify.",
         },
         frameworks={"owasp_llm": "LLM06", "owasp_agentic": "AG04"},
+        default_suggestion="Remove the network call or the credential access from the same component.",
     )
 
     def create(self, context: RuleContext) -> None:

--- a/src/harness_eval/inspection/rules/security/mcp_least_privilege.py
+++ b/src/harness_eval/inspection/rules/security/mcp_least_privilege.py
@@ -68,6 +68,7 @@ class McpLeastPrivilege:
             "mcp_overdeclared": "allowed-tools grants {{capability}} access but no code uses it. Remove unused permissions to follow least-privilege.",
         },
         frameworks={"owasp_agentic": "AG02"},
+        default_suggestion="Restrict the MCP server's tool list to only required tools.",
     )
 
     def create(self, context: RuleContext) -> None:

--- a/src/harness_eval/inspection/rules/security/mcp_tool_poisoning.py
+++ b/src/harness_eval/inspection/rules/security/mcp_tool_poisoning.py
@@ -121,6 +121,7 @@ class McpToolPoisoning:
             "mcp_suspicious_default": "Line {{line}}: {{label}}. Suspicious content pattern detected.",
         },
         frameworks={"owasp_llm": "LLM05", "owasp_agentic": "AG03"},
+        default_suggestion="Pin the MCP server package and validate its tool descriptions.",
     )
 
     def create(self, context: RuleContext) -> None:

--- a/src/harness_eval/inspection/rules/security/memory_write_unscoped.py
+++ b/src/harness_eval/inspection/rules/security/memory_write_unscoped.py
@@ -52,6 +52,7 @@ class MemoryWriteUnscoped:
             ),
         },
         frameworks={"owasp_agentic": "ASI06"},
+        default_suggestion="Scope memory writes to a specific namespace or session.",
     )
 
     def create(self, context: RuleContext) -> None:

--- a/src/harness_eval/inspection/rules/security/no_credential_access.py
+++ b/src/harness_eval/inspection/rules/security/no_credential_access.py
@@ -73,6 +73,7 @@ class NoCredentialAccess:
             "dangerous_command": "Contains dangerous command '{{match}}' at line {{line}}",
         },
         frameworks={"owasp_llm": "LLM06", "owasp_agentic": "AG05"},
+        default_suggestion="Remove direct credential access and use environment variables instead.",
     )
 
     def create(self, context: RuleContext) -> None:

--- a/src/harness_eval/inspection/rules/security/no_prompt_injection.py
+++ b/src/harness_eval/inspection/rules/security/no_prompt_injection.py
@@ -74,6 +74,7 @@ class NoPromptInjection:
             "injection_negated": "Line {{line}} contains '{{label}}' preceded by negation (likely a safety guardrail, not injection).",
         },
         frameworks={"owasp_llm": "LLM01", "mitre_atlas": "AML.T0051"},
+        default_suggestion="Remove or rephrase the flagged text.",
     )
 
     def create(self, context: RuleContext) -> None:

--- a/src/harness_eval/inspection/rules/security/obfuscation_detection.py
+++ b/src/harness_eval/inspection/rules/security/obfuscation_detection.py
@@ -39,6 +39,7 @@ class ObfuscationDetection:
             "obfuscation_in_code_block": "Line {{line}} contains '{{label}}' inside a code block — likely documentation, but verify.",
         },
         frameworks={"owasp_llm": "LLM02", "mitre_atlas": "AML.T0054"},
+        default_suggestion="Replace obfuscated content with plain text.",
     )
 
     def create(self, context: RuleContext) -> None:

--- a/src/harness_eval/inspection/rules/security/prompt_exfiltration.py
+++ b/src/harness_eval/inspection/rules/security/prompt_exfiltration.py
@@ -66,6 +66,7 @@ class PromptExfiltration:
             "exfil_negated": "Line {{line}} contains '{{label}}' preceded by negation (likely a restriction, not exfiltration).",
         },
         frameworks={"owasp_llm": "LLM07"},
+        default_suggestion="Remove instructions that expose system prompts in output.",
     )
 
     def create(self, context: RuleContext) -> None:

--- a/src/harness_eval/inspection/rules/security/reverse_shell_detection.py
+++ b/src/harness_eval/inspection/rules/security/reverse_shell_detection.py
@@ -40,6 +40,7 @@ class ReverseShellDetection:
             "shell_in_code_block": "Line {{line}} contains '{{label}}' inside a code block — likely documentation, but verify.",
         },
         frameworks={"owasp_agentic": "AG04", "mitre_atlas": "AML.T0054"},
+        default_suggestion="Remove the reverse shell pattern from the instructions.",
     )
 
     def create(self, context: RuleContext) -> None:

--- a/src/harness_eval/inspection/rules/security/stealth_persistence.py
+++ b/src/harness_eval/inspection/rules/security/stealth_persistence.py
@@ -47,6 +47,7 @@ class StealthPersistence:
             "persist_in_code_block": "Line {{line}} contains '{{label}}' inside a code block (likely safe).",
         },
         frameworks={"owasp_agentic": "AG04", "mitre_atlas": "AML.T0054"},
+        default_suggestion="Remove instructions that write to config directories.",
     )
 
     def create(self, context: RuleContext) -> None:

--- a/src/harness_eval/inspection/rules/security/taint_tracking.py
+++ b/src/harness_eval/inspection/rules/security/taint_tracking.py
@@ -201,6 +201,7 @@ class TaintTracking:
             "taint_input_exec": "{{file}}: external input (line {{source_line}}) flows to code execution (line {{sink_line}}). Possible injection vector.",
         },
         frameworks={"owasp_llm": "LLM06", "owasp_agentic": "AG04"},
+        default_suggestion="Add input validation before using untrusted data in sensitive operations.",
     )
 
     def create(self, context: RuleContext) -> None:

--- a/src/harness_eval/inspection/rules/security/unbounded_delegation.py
+++ b/src/harness_eval/inspection/rules/security/unbounded_delegation.py
@@ -44,6 +44,7 @@ class UnboundedDelegation:
             ),
         },
         frameworks={"owasp_agentic": "ASI08"},
+        default_suggestion="Add a recursion depth limit to the delegation chain.",
     )
 
     def create(self, context: RuleContext) -> None:

--- a/src/harness_eval/inspection/rules/security/yara_scan.py
+++ b/src/harness_eval/inspection/rules/security/yara_scan.py
@@ -94,6 +94,7 @@ class YaraScan:
             "yara_skipped": "YARA scanning skipped: {{reason}}. Install with: pip install yara-python",
         },
         frameworks={"mitre_atlas": "AML.T0054"},
+        default_suggestion="Remove or replace the content matched by the YARA rule.",
     )
 
     def create(self, context: RuleContext) -> None:

--- a/src/harness_eval/inspection/rules/structural/skill_md_exists.py
+++ b/src/harness_eval/inspection/rules/structural/skill_md_exists.py
@@ -20,6 +20,7 @@ class SkillMdExists:
         messages={
             "not_found": "SKILL.md not found in {{dir}}",
         },
+        default_suggestion="Add a SKILL.md file to the skill directory.",
     )
 
     def create(self, context: RuleContext) -> None:

--- a/src/harness_eval/inspection/types.py
+++ b/src/harness_eval/inspection/types.py
@@ -81,6 +81,7 @@ class RuleMeta:
     target_type: ComponentType = ComponentType.SKILL
     tools: tuple[str, ...] | None = None
     frameworks: dict[str, str] | None = None
+    default_suggestion: str | None = None
 
 
 @dataclass

--- a/src/harness_eval/output/report.py
+++ b/src/harness_eval/output/report.py
@@ -67,10 +67,14 @@ def _compress_findings(diagnostics: list) -> list[str]:
         if len(findings) <= 2:
             for d in findings:
                 compressed.append(f"  {label:<8} {short_id}: {d.message}")
+                if d.suggestion:
+                    compressed.append(f"           Fix: {d.suggestion}")
         else:
             compressed.append(f"  {label:<8} {short_id}: {len(findings)} findings")
             for d in findings:
                 compressed.append(f"           {d.message}")
+            if findings[0].suggestion:
+                compressed.append(f"           Fix: {findings[0].suggestion}")
     return compressed
 
 
@@ -299,6 +303,7 @@ def _build_json_inspection(inspection_results: list[InspectionResult]) -> dict:
                         "rule": d.rule_id,
                         "severity": d.severity.value,
                         "message": d.message,
+                        **({"suggestion": d.suggestion} if d.suggestion else {}),
                     }
                     for d in r.diagnostics
                 ],

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -1,0 +1,70 @@
+"""Tests for LLM client abstraction (utils/llm.py)."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from harness_eval.utils.llm import AnthropicClient, GeminiClient, create_client
+
+
+class TestCreateClient:
+    def test_gemini_default(self) -> None:
+        client = create_client("gemini")
+        assert isinstance(client, GeminiClient)
+        assert client.model == "gemini-2.0-flash"
+
+    def test_anthropic_default(self) -> None:
+        client = create_client("anthropic")
+        assert isinstance(client, AnthropicClient)
+        assert client.model == "claude-sonnet-4-20250514"
+
+    def test_custom_model(self) -> None:
+        client = create_client("gemini", model="gemini-1.5-pro")
+        assert isinstance(client, GeminiClient)
+        assert client.model == "gemini-1.5-pro"
+
+    def test_unknown_provider(self) -> None:
+        with pytest.raises(ValueError, match="Unknown LLM provider"):
+            create_client("openai")
+
+
+class TestGeminiClient:
+    def test_missing_import_raises(self) -> None:
+        client = GeminiClient()
+        with (
+            patch.dict("sys.modules", {"google": None, "google.genai": None}),
+            pytest.raises(ImportError, match="LLM dependencies not installed"),
+        ):
+            client._ensure_client()
+
+    def test_missing_api_key_raises(self) -> None:
+        client = GeminiClient()
+        with patch.dict("os.environ", {}, clear=True), pytest.raises((ImportError, ValueError)):
+            client._ensure_client()
+
+    def test_call_counters_init(self) -> None:
+        client = GeminiClient()
+        assert client.calls_total == 0
+        assert client.calls_succeeded == 0
+
+
+class TestAnthropicClient:
+    def test_missing_import_raises(self) -> None:
+        client = AnthropicClient()
+        with (
+            patch.dict("sys.modules", {"anthropic": None}),
+            pytest.raises(ImportError, match="LLM dependencies not installed"),
+        ):
+            client._ensure_client()
+
+    def test_missing_api_key_raises(self) -> None:
+        client = AnthropicClient()
+        with patch.dict("os.environ", {}, clear=True), pytest.raises((ImportError, ValueError)):
+            client._ensure_client()
+
+    def test_call_counters_init(self) -> None:
+        client = AnthropicClient()
+        assert client.calls_total == 0
+        assert client.calls_succeeded == 0

--- a/tests/test_suppression_edge_cases.py
+++ b/tests/test_suppression_edge_cases.py
@@ -1,0 +1,63 @@
+"""Edge case tests for the suppression system."""
+
+from __future__ import annotations
+
+from harness_eval.inspection.suppression import is_suppressed, parse_suppressions
+
+
+class TestParseSuppressions:
+    def test_file_wide_single_rule(self) -> None:
+        content = "<!-- evaluator-ignore: security/no-prompt-injection -->\n# Hello"
+        sups = parse_suppressions(content)
+        assert "security/no-prompt-injection" in sups.get(None, set())
+
+    def test_file_wide_multiple_rules(self) -> None:
+        content = "<!-- evaluator-ignore: rule-a, rule-b, rule-c -->\n# Hello"
+        sups = parse_suppressions(content)
+        assert sups[None] == {"rule-a", "rule-b", "rule-c"}
+
+    def test_next_line_suppression(self) -> None:
+        content = "line 1\n<!-- evaluator-ignore-next-line: my-rule -->\nflagged line"
+        sups = parse_suppressions(content)
+        assert "my-rule" in sups.get(3, set())
+
+    def test_empty_content(self) -> None:
+        sups = parse_suppressions("")
+        assert sups == {}
+
+    def test_no_suppression_comments(self) -> None:
+        sups = parse_suppressions("# Just markdown\nNo suppressions here.")
+        assert sups == {}
+
+    def test_case_insensitive(self) -> None:
+        content = "<!-- EVALUATOR-IGNORE: my-rule -->\n"
+        sups = parse_suppressions(content)
+        assert "my-rule" in sups.get(None, set())
+
+    def test_whitespace_in_rule_list(self) -> None:
+        content = "<!-- evaluator-ignore:  rule-a ,  rule-b  -->\n"
+        sups = parse_suppressions(content)
+        assert sups[None] == {"rule-a", "rule-b"}
+
+
+class TestIsSuppressed:
+    def test_file_wide_suppresses_any_line(self) -> None:
+        sups = {None: {"my-rule"}}
+        assert is_suppressed(sups, "my-rule", 1)
+        assert is_suppressed(sups, "my-rule", 100)
+
+    def test_line_specific(self) -> None:
+        sups = {5: {"my-rule"}}
+        assert is_suppressed(sups, "my-rule", 5)
+        assert not is_suppressed(sups, "my-rule", 4)
+
+    def test_unrelated_rule_not_suppressed(self) -> None:
+        sups = {None: {"rule-a"}}
+        assert not is_suppressed(sups, "rule-b", 1)
+
+    def test_empty_suppressions(self) -> None:
+        assert not is_suppressed({}, "any-rule", 1)
+
+    def test_none_line(self) -> None:
+        sups = {None: {"my-rule"}}
+        assert is_suppressed(sups, "my-rule", None)


### PR DESCRIPTION
## Summary

Four issues implemented in one PR.

### #55: Fix suggestions for all 92 rules
Every finding now includes an actionable "Fix:" line. Added `default_suggestion` field to `RuleMeta`; the engine falls back to it when no per-finding suggestion is set. All 92 rules have suggestions. Terminal and JSON output both render them.

### #49: Command generation from one source
`scripts/sync_commands.py` generates Claude Code `commands/` stubs from `.cursor/commands/` source. Supports `--check` for CI drift detection. Regenerated all 4 command stubs.

### #50: Suggestion rendering in output
Terminal output shows "Fix:" below findings. JSON output includes `suggestion` field when present. Both `format_terminal()` and `format_json()` in `output/report.py` updated.

### #36: Test coverage (22 new tests)
- `test_llm_client.py`: create_client, missing imports, missing API keys, call counters
- `test_suppression_edge_cases.py`: file-wide, next-line, case-insensitive, empty content, line-specific

Closes #36, closes #49, closes #50, closes #55.

## Test plan
- [x] 846 tests passed, 0 failures
- [x] `ruff check` and `ruff format` clean
- [x] Suggestions visible in `harness-eval lint` terminal output ("Fix:" lines)
- [x] `scripts/sync_commands.py --check` passes