### PR TITLE
fix: 5 bugs found in v7.7.0

### DIFF
--- a/.cursor/commands/harness-lint.md
+++ b/.cursor/commands/harness-lint.md
@@ -9,7 +9,7 @@ Run 92 deterministic rules + system-level analysis on the agent setup. No LLM. F
 2. Run the lint command on the current project:
 
 ```bash
-harness-eval lint .
+harness-eval harness-lint .
 ```
 
 If `harness-eval` is not installed, try `pip install harness-eval` first.
@@ -17,7 +17,7 @@ If `harness-eval` is not installed, try `pip install harness-eval` first.
 For JSON output (if the user prefers file output):
 
 ```bash
-harness-eval lint . --format json
+harness-eval harness-lint . --format json
 ```
 
 3. Present the report. Include all sections: inventory, token budget, trigger analysis, dependencies, findings, and inspection summary.

--- a/.cursor/commands/harness-review.md
+++ b/.cursor/commands/harness-review.md
@@ -17,7 +17,7 @@ Ask the user: print the report in conversation, or write to a file?
 Run the deterministic scan first to get structural data:
 
 ```bash
-harness-eval lint . --format json
+harness-eval harness-lint . --format json
 ```
 
 If `harness-eval` is not installed, try `pip install harness-eval` first.

--- a/.cursor/commands/harness-security.md
+++ b/.cursor/commands/harness-security.md
@@ -16,7 +16,7 @@ Ask the user: print the report in conversation, or write to a file?
 ## Step 2: Run Deterministic Security Scan
 
 ```bash
-harness-eval security .
+harness-eval harness-security .
 ```
 
 If `harness-eval` is not installed, try `pip install harness-eval` first.

--- a/.cursor/commands/skill-review.md
+++ b/.cursor/commands/skill-review.md
@@ -23,7 +23,7 @@ Determine the skill path from $ARGUMENTS. If the user says a skill name, find it
 ## Step 3: Run Lint
 
 ```bash
-harness-eval skill <skill-path> --context .
+harness-eval skill-review <skill-path> --context .
 ```
 
 If `harness-eval` is not installed, try `pip install harness-eval` first.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,9 @@ jobs:
         continue-on-error: true
         run: uv run mypy src/ --ignore-missing-imports
 
+      - name: Command surface sync check
+        run: uv run scripts/sync_commands.py --check
+
   test:
     runs-on: ubuntu-latest
     strategy:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- **Cursor commands broken**: `.cursor/commands/*.md` bodies referenced old CLI names (`harness-eval lint` instead of `harness-eval harness-lint`). All 5 Cursor commands updated.
+- **`skill-verify` fails on bare skill directories**: now falls back to parsing as a single skill when `SKILL.md` exists but `discover_setup` finds no components.
+- **YAML custom rules unusable for pip users**: now also loads from `.harness-eval/rules/` in the project directory, not just the installed package's internal `rules/custom/`.
+- **Command surface drift shipped uncaught**: added `sync_commands.py --check` to CI lint job.
+- **INSTALL.md docs drift**: updated plugin command names, Cursor command names, added `skill-verify` to command lists, fixed Tekton build version.
+
 ## [7.7.0] - 2026-08-10
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ See [`docs/how-can-you-know-its-safe-to-use-this-tool.md`](docs/how-can-you-know
 
 ## Custom YAML rules
 
-Add your own rules without writing Python. Drop a `.yaml` file in `src/harness_eval/inspection/rules/custom/`:
+Add your own rules without writing Python. Drop a `.yaml` file in `.harness-eval/rules/` in your project:
 
 ```yaml
 id: custom/no-sudo

--- a/commands/skill-verify.md
+++ b/commands/skill-verify.md
@@ -1,15 +1,13 @@
 ---
-description: "Vet a skill or setup before installing. Combines lint + security checks in one pass."
+description: "Vet a skill or setup before installing. Combines lint + security checks in one pass"
 ---
 
 # Skill Verify
 
-Run `harness-eval skill-verify` on the path provided in $ARGUMENTS.
+Use the Skill tool to invoke `eval-skill` explicitly.
 
-```bash
-harness-eval skill-verify $ARGUMENTS
-```
+Pass through any arguments from $ARGUMENTS (e.g., a specific path to evaluate).
 
-If `harness-eval` is not installed, tell the user to run `pip install harness-eval` first.
-
-Present the verdict (SAFE / CAUTION / UNSAFE) and any findings with fix suggestions.
+If the Skill tool is not available or the skill is not found, tell the user:
+- Check that `skills/eval-skill/SKILL.md` exists in the workspace
+- If not, reinstall the harness-eval plugin

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -148,10 +148,10 @@ Run harness-eval as a CI gate in OpenShift Pipelines. Requires the OpenShift Pip
 
 ```bash
 # Build the image
-podman build -t harness-eval:7.5.0 -f Containerfile .
+podman build -t harness-eval:7.7.1 -f Containerfile .
 
 # Push to your registry (internal OpenShift, quay.io, etc.)
-podman push harness-eval:7.5.0 <your-registry>/harness-eval:7.5.0
+podman push harness-eval:7.7.1 <your-registry>/harness-eval:7.7.1
 
 # Apply the Task and Pipeline
 oc apply -f tekton/task-harness-eval.yaml
@@ -173,11 +173,12 @@ No pip install needed. Install directly from within Claude Code:
 /reload-plugins
 ```
 
-The 4 commands appear in the `/` menu:
-- `/harness-eval:lint`
-- `/harness-eval:review`
-- `/harness-eval:security`
-- `/harness-eval:skill`
+The 5 commands appear in the `/` menu:
+- `/harness-eval:harness-lint`
+- `/harness-eval:harness-review`
+- `/harness-eval:harness-security`
+- `/harness-eval:skill-review`
+- `/harness-eval:skill-verify`
 
 No API key needed. Claude evaluates in-session.
 
@@ -191,10 +192,11 @@ Requires the CLI tool installed first (Cursor commands call it for the determini
 pip install harness-eval
 ```
 
-Then copy `.cursor/commands/` from [this repo](https://github.com/redhat-community-ai-tools/harness-eval) into your project. The 4 commands appear in Cursor's command palette:
-- `/lint`
-- `/review`
-- `/security`
-- `/skill`
+Then copy `.cursor/commands/` from [this repo](https://github.com/redhat-community-ai-tools/harness-eval) into your project. The 5 commands appear in Cursor's command palette:
+- `/harness-lint`
+- `/harness-review`
+- `/harness-security`
+- `/skill-review`
+- `/skill-verify`
 
-No API key needed for review/security/skill. Cursor evaluates in-session.
+No API key needed for harness-review/harness-security/skill-review. Cursor evaluates in-session.

--- a/src/harness_eval/cli/scan.py
+++ b/src/harness_eval/cli/scan.py
@@ -33,6 +33,22 @@ def scan_skill(path: str, fmt: str, fail_on_error: bool, fail_on_warning: bool) 
 
     setup = discover_setup(name=target.name, path=str(target))
 
+    if not setup.components and (target / "SKILL.md").exists():
+        from harness_eval.core.types import ComponentType
+        from harness_eval.inspection.parsers import parse_skill
+
+        skill = parse_skill(str(target))
+        from harness_eval.core.types import ParsedComponent
+
+        setup.components.append(
+            ParsedComponent(
+                name=skill.dir_name,
+                component_type=ComponentType.SKILL,
+                path=skill.skill_md_path,
+                content=skill.raw_content,
+            )
+        )
+
     if not setup.components:
         click.echo(f"No agent components found in {path}.", err=True)
         raise SystemExit(1)

--- a/src/harness_eval/inspection/yaml_rules.py
+++ b/src/harness_eval/inspection/yaml_rules.py
@@ -199,6 +199,10 @@ def load_yaml_rules(search_paths: list[Path] | None = None) -> int:
     if default_dir.is_dir():
         paths.insert(0, default_dir)
 
+    project_dir = Path.cwd() / ".harness-eval" / "rules"
+    if project_dir.is_dir() and project_dir not in paths:
+        paths.append(project_dir)
+
     total = 0
     for p in paths:
         total += load_yaml_rules_from_dir(p)


### PR DESCRIPTION
## Summary

5 bugs found in v7.7.0 by post-release review.

1. **Cursor commands broken**: bodies still referenced old CLI names. All 5 updated.
2. **skill-verify fails on bare skill dirs**: now falls back to single-skill parse when SKILL.md exists.
3. **YAML rules unusable for pip users**: now also loads from `.harness-eval/rules/` in project dir.
4. **Command drift shipped uncaught**: added `sync_commands.py --check` to CI lint job.
5. **INSTALL.md drift**: updated plugin/Cursor command names, added skill-verify, fixed Tekton version.

## Test plan
- [x] 877 tests passed, 0 failures
- [x] `sync_commands.py --check` passes
- [x] ruff clean