### PR TITLE
fix: YAML rules engine, README accuracy, badge drift test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- **YAML custom rules now execute during `harness-lint`**: rules with `custom/` prefix are no longer skipped by preset whitelisting. Previously, custom YAML rules were loaded and listed by `rules` but never fired during lint.
+- **README accuracy**: Windsurf/Cline changed from "discovery + structure rules" to "discovery only". Gemini row notes `.toml` commands are discovered but not yet linted. YAML rules section documents that custom rules run under every preset.
+
+### Added
+- Example output block in README Quick start showing findings with Fix: lines
+- `skill-verify` highlighted in Quick start section
+- Badge drift test for README `rules-92` badge
+
 ## [7.7.1] - 2026-08-10
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -14,8 +14,20 @@ Most tools test whether a skill produces correct output. This one checks the set
 
 ```bash
 pip install harness-eval
-harness-eval harness-lint .          # 92 deterministic rules, fully offline
-harness-eval harness-security .      # security scan (18 rules)
+harness-eval harness-lint .                    # 92 deterministic rules, fully offline
+harness-eval harness-security .                # security scan
+harness-eval skill-verify ./downloaded-skill   # SAFE / CAUTION / UNSAFE before you install
+```
+
+Example output:
+
+```
+FAIL     no-credential-access: References sensitive path '~/.aws/credentials' at line 10
+             Fix: Use a secret manager or environment variable injection instead of hardcoded paths.
+WARNING  orphan-skills: Skill 'creds-skill' is not referenced by any command, CLAUDE.md, or agent
+             Fix: Reference the skill from a command, CLAUDE.md, or agent, or remove it.
+
+Verdict: UNSAFE
 ```
 
 See [`docs/INSTALL.md`](docs/INSTALL.md) for all installation options and configuration.
@@ -51,10 +63,10 @@ Multi-tool projects are fully supported. When a project uses both Claude Code an
 |-----------|------------------|
 | Claude Code | `CLAUDE.md`, `skills/`, `commands/`, `.claude/agents/`, `.claude/settings.json`, `.mcp.json` |
 | Cursor | `.cursor/rules/*.mdc`, `.cursorrules`, `.cursor/commands/`, `.cursor/skills/`, `.cursor/hooks.json`, `.cursor/mcp.json` |
-| Windsurf | `.windsurfrules`, `.windsurf/rules/*.md` (discovery + structure rules) |
-| Cline | `.clinerules` (file or directory of `*.md`) (discovery + structure rules) |
+| Windsurf | `.windsurfrules`, `.windsurf/rules/*.md` (discovery only) |
+| Cline | `.clinerules` (file or directory of `*.md`) (discovery only) |
 | Copilot | `.github/copilot-instructions.md`, `.github/skills/`, `.github/prompts/`, `.github/agents/` |
-| Gemini CLI | `GEMINI.md`, `.gemini/commands/`, `.gemini/settings.json` (MCP) |
+| Gemini CLI | `GEMINI.md`, `.gemini/commands/` (`.md` linted; `.toml` discovered but not yet linted), `.gemini/settings.json` (MCP) |
 | OpenCode | `AGENTS.md`, `.opencode/commands/`, `.opencode/agents/`, `opencode.json` (MCP) |
 | Third-party modules | `.lola/modules/` (skills, commands, agents installed via package managers) |
 
@@ -94,7 +106,7 @@ patterns:
 message: "Found '{{label}}' on line {{line}}"
 ```
 
-YAML rules support regex pattern matching on component content. Patterns are case-insensitive by default. For complex logic (AST analysis, cross-component checks), use Python rules instead.
+YAML rules support regex pattern matching on component content. Patterns are case-insensitive by default. Custom rules run at their declared severity under every preset. Disable one with `custom/no-sudo: off` in your config. For complex logic (AST analysis, cross-component checks), use Python rules instead.
 
 ## Contributing
 

--- a/src/harness_eval/inspection/engine.py
+++ b/src/harness_eval/inspection/engine.py
@@ -67,7 +67,7 @@ def _resolve_severity(
     if severity_config == "off":
         return None
 
-    if severity_config is None and config_rules:
+    if severity_config is None and config_rules and not rule.meta.id.startswith("custom/"):
         return None
 
     explicitly_configured = severity_config is not None

--- a/tests/test_doc_counts.py
+++ b/tests/test_doc_counts.py
@@ -71,6 +71,21 @@ class TestRuleCountDrift:
                 )
 
 
+class TestReadmeBadge:
+    def test_badge_rule_count_matches_registry(self) -> None:
+        total, _ = _get_rule_counts()
+        readme = ROOT / "README.md"
+        badge_pattern = re.compile(r"rules-(\d+)-blue")
+        for line in readme.read_text().splitlines():
+            m = badge_pattern.search(line)
+            if m:
+                assert int(m.group(1)) == total, (
+                    f"README.md badge says {m.group(1)} rules but registry has {total}."
+                )
+                return
+        raise AssertionError("No rules badge found in README.md")
+
+
 class TestRulesReferenceCompleteness:
     def test_every_rule_is_documented(self) -> None:
         rules_ref = ROOT / "docs" / "rules-reference.md"


### PR DESCRIPTION
## Summary

Fixes the last gap between what the repo claims and what it does.

- **YAML custom rules now actually fire during harness-lint.** Rules with `custom/` prefix were silently skipped by preset whitelisting. One-line engine fix.
- **README accuracy:** Windsurf/Cline changed to "discovery only". Gemini row notes .toml not yet linted. YAML section documents preset behavior and disabling.
- **README additions:** output example in Quick start, skill-verify highlighted.
- **Badge drift test** for the hardcoded `rules-92` badge.

878 tests, 0 failures.