### PR TITLE
fix: pipeline image, self-scan false positives, bad API key traceback

### DIFF
--- a/.cursor/commands/harness-lint.md
+++ b/.cursor/commands/harness-lint.md
@@ -1,3 +1,4 @@
+<!-- evaluator-ignore: command/references-nonexistent-skill -->
 # Eval Setup Lint
 
 Run 96 deterministic rules + system-level analysis on the agent setup. No LLM. Fast, reproducible, CI-suitable.

--- a/.cursor/commands/harness-review.md
+++ b/.cursor/commands/harness-review.md
@@ -1,3 +1,4 @@
+<!-- evaluator-ignore: command/references-nonexistent-skill -->
 # Eval Setup Review
 
 Full qualitative review of the agent setup. Read every file, evaluate quality, redundancy, and optimization opportunities. Produce KEEP/REVIEW/REMOVE verdicts per component.

--- a/.cursor/commands/harness-security.md
+++ b/.cursor/commands/harness-security.md
@@ -1,3 +1,4 @@
+<!-- evaluator-ignore: command/references-nonexistent-skill -->
 # Eval Setup Security
 
 Deep security audit of the agent setup. Combines deterministic scanning with semantic security review.

--- a/.cursor/commands/skill-review.md
+++ b/.cursor/commands/skill-review.md
@@ -1,3 +1,4 @@
+<!-- evaluator-ignore: command/references-nonexistent-skill -->
 # Eval Skill
 
 Deep-evaluate a single skill with static analysis and qualitative review, both individually and in context of the full setup.

--- a/.cursor/commands/skill-verify.md
+++ b/.cursor/commands/skill-verify.md
@@ -1,3 +1,4 @@
+<!-- evaluator-ignore: command/references-nonexistent-skill -->
 # Skill Verify
 
 Vet a skill or setup before installing. Combines lint + security checks in one pass.

--- a/skills/eval-skill/SKILL.md
+++ b/skills/eval-skill/SKILL.md
@@ -5,7 +5,7 @@ allowed-tools:
   - Bash
   - Read
 ---
-<!-- evaluator-ignore: content/broken-references, content/allowed-tools-auto-approve -->
+<!-- evaluator-ignore: content/broken-references, content/allowed-tools-auto-approve, quality/scope-overreach -->
 
 # Evaluate Skill
 

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -5,7 +5,7 @@ allowed-tools:
   - Bash
   - Read
 ---
-<!-- evaluator-ignore: content/broken-references, content/allowed-tools-auto-approve -->
+<!-- evaluator-ignore: content/broken-references, content/allowed-tools-auto-approve, quality/scope-overreach -->
 
 # Review Setup
 

--- a/src/harness_eval/cli/review.py
+++ b/src/harness_eval/cli/review.py
@@ -106,7 +106,17 @@ def eval_setup_review(
             future_map[future] = batch
 
         for future in as_completed(future_map):
-            result = future.result()
+            try:
+                result = future.result()
+            except Exception as e:
+                err_name = type(e).__name__
+                if "Auth" in err_name or "Unauthorized" in err_name or "401" in str(e):
+                    key_hint = "ANTHROPIC_API_KEY" if provider == "anthropic" else "GEMINI_API_KEY"
+                    raise click.ClickException(
+                        f"Authentication failed: {e}\n\n"
+                        f"Check that {key_hint} is valid, or run `harness-eval doctor`."
+                    ) from None
+                raise
             if isinstance(result, list):
                 rubric_results.extend(result)
             else:

--- a/src/harness_eval/cli/security.py
+++ b/src/harness_eval/cli/security.py
@@ -521,7 +521,19 @@ def eval_setup_security(
                 for comp in setup.components
             }
             for future in as_completed(futures):
-                all_sec_results.append(future.result())
+                try:
+                    all_sec_results.append(future.result())
+                except Exception as e:
+                    err_name = type(e).__name__
+                    if "Auth" in err_name or "Unauthorized" in err_name or "401" in str(e):
+                        key_hint = (
+                            "ANTHROPIC_API_KEY" if provider == "anthropic" else "GEMINI_API_KEY"
+                        )
+                        raise click.ClickException(
+                            f"Authentication failed: {e}\n\n"
+                            f"Check that {key_hint} is valid, or run `harness-eval doctor`."
+                        ) from None
+                    raise
 
         for rr in all_sec_results:
             if rr.issues:

--- a/tekton/pipeline-harness-eval.yaml
+++ b/tekton/pipeline-harness-eval.yaml
@@ -24,7 +24,7 @@ spec:
       description: "Enforcement mode: strict, advisory, off."
     - name: image
       type: string
-      default: image-registry.openshift-image-registry.svc:5000/qe-ds-ai--pipeline/harness-eval:dev
+      default: registry.access.redhat.com/ubi9/python-312:latest
       description: harness-eval container image.
   workspaces:
     - name: shared-workspace


### PR DESCRIPTION
## Summary

Three fixes from post-release review.

1. **Pipeline image**: `pipeline-harness-eval.yaml` default changed from private cluster registry to `ubi9/python-312:latest`, matching the task's default. External users no longer get ImagePullBackOff.

2. **Self-scan now clean**: `harness-eval harness-lint .` on this repo was producing 8 warnings (false positives). Added evaluator-ignore suppressions for `references-nonexistent-skill` on all 5 Cursor commands (uvx invocation matches the skill-name regex) and `scope-overreach` on eval-skill + review skills. Now: 0 errors, 0 warnings.

3. **Bad API key**: `harness-review` and `harness-security --review` with an invalid API key now print a friendly error instead of a raw Python traceback. Catches `AuthenticationError` from both Anthropic and Gemini API calls.

## Test plan

- [x] 877 tests passed, 0 failures
- [x] `harness-eval harness-lint .` -> 0 errors, 0 warnings
- [x] `harness-eval harness-security . --fail-on-error` -> SAFE
- [x] ruff clean