### PR TITLE
fix: resolve broken-references via paths frontmatter context

### DIFF
--- a/src/harness_eval/inspection/rules/content/broken_references.py
+++ b/src/harness_eval/inspection/rules/content/broken_references.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import re
 from pathlib import Path
+from typing import Any
 
 from harness_eval.inspection.types import (
     Location,
@@ -23,6 +24,8 @@ _TEMPLATE_VAR_RE = re.compile(r"\$\{|\$[A-Z_][A-Z0-9_]*|<[a-z_-]+>|\{\{")
 _GLOB_RE = re.compile(r"[*?]")
 _COMMAND_RE = re.compile(r"^(git|bash|uv|npm|curl|grep|tail|mv|cat|echo|find|sed|awk)\s")
 _PLACEHOLDER_RE = re.compile(r"[A-Z]{3,4}[A-Z0-9]*-")
+_GLOB_DIR_RE = re.compile(r"^([^*?{]+?)(?:/\*\*?.*)?$")
+
 _KNOWN_EXTENSIONS = frozenset(
     {
         "py",
@@ -95,6 +98,22 @@ def _fenced_lines(lines: list[str]) -> set[int]:
     return fenced
 
 
+def _paths_base_dirs(frontmatter: dict[str, Any]) -> list[str]:
+    """Extract base directories from a skill's paths frontmatter field."""
+    raw = frontmatter.get("paths")
+    if not raw:
+        return []
+    entries = [raw] if isinstance(raw, str) else list(raw)
+    dirs: list[str] = []
+    for entry in entries:
+        m = _GLOB_DIR_RE.match(entry.strip())
+        if m:
+            base = m.group(1).rstrip("/")
+            if base and base != ".":
+                dirs.append(base)
+    return dirs
+
+
 class BrokenReferences:
     meta: RuleMeta = RuleMeta(
         id="content/broken-references",
@@ -160,6 +179,13 @@ class BrokenReferences:
                         root_resolved = project_root_path.resolve()
                         if str(resolved).startswith(str(root_resolved)) and resolved.exists():
                             continue
+
+                    paths_dirs = _paths_base_dirs(skill.frontmatter)
+                    if any(
+                        (p := safe_join(project_root_path / d, ref)) is not None and p.exists()
+                        for d in paths_dirs
+                    ):
+                        continue
 
                 context.report(
                     ReportDescriptor(

--- a/tests/test_inspection.py
+++ b/tests/test_inspection.py
@@ -300,6 +300,44 @@ class TestContentRules:
         broken = [d for d in result.diagnostics if d.rule_id == "content/broken-references"]
         assert len(broken) == 1
 
+    def test_broken_reference_resolves_via_paths_frontmatter(self, tmp_path: Path) -> None:
+        project = tmp_path / "project"
+        project.mkdir()
+        backend = project / "backend" / "admin_config"
+        backend.mkdir(parents=True)
+        (backend / "service.py").write_text("# service")
+        skill_dir = project / ".cursor" / "skills" / "backend"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: backend\ndescription: Backend domain knowledge\n"
+            "paths: backend/**\n---\n\n"
+            "Key file: `admin_config/service.py`"
+        )
+        result = lint(
+            str(skill_dir),
+            scan_state={"project_root": str(project)},
+        )
+        broken = [d for d in result.diagnostics if d.rule_id == "content/broken-references"]
+        assert len(broken) == 0
+
+    def test_broken_reference_paths_frontmatter_still_catches_missing(self, tmp_path: Path) -> None:
+        project = tmp_path / "project"
+        project.mkdir()
+        (project / "backend").mkdir()
+        skill_dir = project / ".cursor" / "skills" / "backend"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: backend\ndescription: Backend domain knowledge\n"
+            "paths: backend/**\n---\n\n"
+            "Key file: `admin_config/service.py`"
+        )
+        result = lint(
+            str(skill_dir),
+            scan_state={"project_root": str(project)},
+        )
+        broken = [d for d in result.diagnostics if d.rule_id == "content/broken-references"]
+        assert len(broken) == 1
+
     def test_broken_reference_skips_bare_env_vars(self, tmp_path: Path) -> None:
         skill_dir = tmp_path / "env-ref"
         skill_dir.mkdir()


### PR DESCRIPTION
## Summary

Skills with a `paths:` frontmatter field (e.g., `paths: backend/**`) reference files relative to that directory, not the skill's own location or the repo root. The broken-references rule was not aware of this, causing false positive errors for every domain-scoped skill.

The fix extracts base directories from the `paths:` frontmatter and tries resolving references from `project_root / base_dir` before flagging.

## Impact

Tested against UnifAI's Cursor setup (11 domain-scoped skills):
- **Before**: 69 errors (68 broken-references)
- **After**: 29 errors (40 false positives eliminated)

The remaining 29 are genuine broken references (files that don't exist under the declared path context either).

## Changes

- `src/harness_eval/inspection/rules/content/broken_references.py`: add `_paths_base_dirs()` helper + resolution step after project_root check
- `tests/test_inspection.py`: 2 new tests (paths-context resolves correctly, still catches truly missing files)

## Test plan

- [x] All 907 existing tests pass
- [x] 2 new tests cover the fix and the negative case
- [x] `ruff check` and `ruff format` clean