### PR TITLE
fix: skip binary files in uncategorized component discovery

### DIFF
--- a/src/harness_eval/core/setup.py
+++ b/src/harness_eval/core/setup.py
@@ -152,6 +152,63 @@ def _deduplicate_components(components: list[ParsedComponent]) -> list[ParsedCom
     return deduped
 
 
+_BINARY_SUFFIXES = frozenset(
+    {
+        ".docx",
+        ".doc",
+        ".xlsx",
+        ".xls",
+        ".pptx",
+        ".ppt",
+        ".pdf",
+        ".odt",
+        ".ods",
+        ".odp",
+        ".png",
+        ".jpg",
+        ".jpeg",
+        ".gif",
+        ".bmp",
+        ".ico",
+        ".svg",
+        ".webp",
+        ".zip",
+        ".gz",
+        ".tar",
+        ".bz2",
+        ".xz",
+        ".7z",
+        ".rar",
+        ".woff",
+        ".woff2",
+        ".ttf",
+        ".otf",
+        ".eot",
+        ".pyc",
+        ".pyo",
+        ".so",
+        ".dll",
+        ".dylib",
+        ".o",
+        ".a",
+        ".exe",
+        ".bin",
+        ".class",
+        ".jar",
+        ".war",
+        ".mp3",
+        ".mp4",
+        ".wav",
+        ".avi",
+        ".mov",
+        ".mkv",
+        ".sqlite",
+        ".db",
+        ".sqlite3",
+    }
+)
+
+
 def _discover_uncategorized(
     root: Path, known_components: list[ParsedComponent]
 ) -> list[ParsedComponent]:
@@ -181,6 +238,8 @@ def _discover_uncategorized(
             if not f.is_file():
                 continue
             if ".git" in f.parts or "__pycache__" in f.parts:
+                continue
+            if f.suffix.lower() in _BINARY_SUFFIXES:
                 continue
             resolved = str(f.resolve())
             if resolved in known_paths:


### PR DESCRIPTION
## Summary

Binary files (.docx, .pdf, .png, etc.) in agent config directories were being read as text and scanned with security rules, producing thousands of false positive warnings (e.g., Cyrillic homoglyphs in Word document binary content).

Adds a `_BINARY_SUFFIXES` set to `_discover_uncategorized` that skips known binary extensions before parsing.

## Impact

Tested against UnifAI (.cursor/ contains a .docx file):
- **Before**: 2,752 warnings (2,720 from one .docx file)
- **After**: 32 warnings

## Test plan

- [x] All 907 existing tests pass
- [x] `ruff check` and `ruff format` clean