### PR TITLE
fix: validate changelog additions are scoped to Unreleased

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,9 @@ jobs:
             echo "Skipping: PR title does not indicate a feature/fix commit."
           fi
 
+      - name: Validate CHANGELOG.md section scope
+        run: python3 scripts/validate_changelog.py --base-ref origin/main
+
   dogfood:
     runs-on: ubuntu-latest
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- CI validation rejects additions to existing changelog release sections while allowing entries under `[Unreleased]` and newly cut releases
+
 ## [7.10.0] - 2026-08-17
 
 ### Added

--- a/scripts/validate_changelog.py
+++ b/scripts/validate_changelog.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+"""Reject additions to changelog sections that already exist on the base branch.
+
+Normal pull requests may add entries under ``[Unreleased]``. Release pull
+requests may create a new version section. Existing release sections are
+historical records, so adding content to them is almost always accidental.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from difflib import SequenceMatcher
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+CHANGELOG = ROOT / "CHANGELOG.md"
+SECTION_RE = re.compile(r"^## \[([^]]+)](?:\s+-.*)?\s*$")
+
+
+@dataclass(frozen=True)
+class ChangelogSection:
+    """A second-level bracketed changelog section and its body."""
+
+    name: str | None
+    header: str | None
+    header_line: int | None
+    body: tuple[str, ...]
+    body_start_line: int
+
+
+@dataclass(frozen=True)
+class Violation:
+    """An added line found outside an allowed changelog section."""
+
+    line: int
+    section: str
+    content: str
+
+
+def parse_sections(text: str) -> list[ChangelogSection]:
+    """Split changelog text into its preamble and version sections."""
+    lines = text.splitlines()
+    sections: list[ChangelogSection] = []
+    name: str | None = None
+    header: str | None = None
+    header_line: int | None = None
+    body_start_line = 1
+    body: list[str] = []
+
+    for line_number, line in enumerate(lines, start=1):
+        match = SECTION_RE.match(line)
+        if match:
+            sections.append(
+                ChangelogSection(
+                    name=name,
+                    header=header,
+                    header_line=header_line,
+                    body=tuple(body),
+                    body_start_line=body_start_line,
+                )
+            )
+            name = match.group(1)
+            header = line
+            header_line = line_number
+            body_start_line = line_number + 1
+            body = []
+        else:
+            body.append(line)
+
+    sections.append(
+        ChangelogSection(
+            name=name,
+            header=header,
+            header_line=header_line,
+            body=tuple(body),
+            body_start_line=body_start_line,
+        )
+    )
+    return sections
+
+
+def _section_key(section: ChangelogSection) -> str:
+    return section.name if section.name is not None else "<preamble>"
+
+
+def validate_changelog(base_text: str, candidate_text: str) -> list[Violation]:
+    """Return meaningful additions made to pre-existing historical sections."""
+    base_sections = {_section_key(section): section for section in parse_sections(base_text)}
+    candidate_sections = parse_sections(candidate_text)
+    violations: list[Violation] = []
+
+    for candidate in candidate_sections:
+        key = _section_key(candidate)
+
+        # Normal changes belong in Unreleased. A section absent from the base
+        # is a newly cut release and is also allowed.
+        if candidate.name == "Unreleased" or key not in base_sections:
+            continue
+
+        base = base_sections[key]
+        if candidate.header != base.header and candidate.header_line is not None:
+            violations.append(
+                Violation(
+                    line=candidate.header_line,
+                    section=key,
+                    content=candidate.header or "",
+                )
+            )
+
+        matcher = SequenceMatcher(a=base.body, b=candidate.body, autojunk=False)
+        for (
+            operation,
+            _base_start,
+            _base_end,
+            candidate_start,
+            candidate_end,
+        ) in matcher.get_opcodes():
+            if operation not in {"insert", "replace"}:
+                continue
+            for offset in range(candidate_start, candidate_end):
+                content = candidate.body[offset]
+                if not content.strip():
+                    continue
+                violations.append(
+                    Violation(
+                        line=candidate.body_start_line + offset,
+                        section=key,
+                        content=content,
+                    )
+                )
+
+    return violations
+
+
+def _git(*args: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=ROOT,
+        check=check,
+        capture_output=True,
+        text=True,
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Ensure changelog additions are limited to Unreleased or a new release section."
+    )
+    parser.add_argument(
+        "--base-ref",
+        default="origin/main",
+        help="Git ref used for the base CHANGELOG.md (default: origin/main).",
+    )
+    args = parser.parse_args()
+
+    changed = _git("diff", "--quiet", f"{args.base_ref}...HEAD", "--", "CHANGELOG.md", check=False)
+    if changed.returncode == 0:
+        print("CHANGELOG.md is unchanged; scope validation skipped.")
+        return 0
+    if changed.returncode != 1:
+        sys.stderr.write(changed.stderr)
+        return changed.returncode
+
+    try:
+        base_text = _git("show", f"{args.base_ref}:CHANGELOG.md").stdout
+    except subprocess.CalledProcessError as error:
+        sys.stderr.write(error.stderr)
+        return error.returncode
+
+    candidate_text = CHANGELOG.read_text(encoding="utf-8")
+    violations = validate_changelog(base_text, candidate_text)
+    if not violations:
+        print("CHANGELOG.md additions are limited to [Unreleased] or a new release section.")
+        return 0
+
+    for violation in violations:
+        section = violation.section.replace("<preamble>", "the changelog preamble")
+        content = (
+            violation.content.strip().replace("%", "%25").replace("\r", "%0D").replace("\n", "%0A")
+        )
+        print(
+            f"::error file=CHANGELOG.md,line={violation.line}::"
+            f"Added content to existing section {section}: {content}"
+        )
+    print("Add changelog entries under [Unreleased] instead.", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_validate_changelog.py
+++ b/tests/test_validate_changelog.py
@@ -1,0 +1,95 @@
+"""Tests for changelog section scope validation."""
+
+from scripts.validate_changelog import validate_changelog
+
+BASE_CHANGELOG = """\
+# Changelog
+
+## [Unreleased]
+
+## [1.1.0] - 2026-08-01
+
+### Added
+- Existing feature
+
+## [1.0.0] - 2026-07-01
+
+### Added
+- Initial release
+"""
+
+
+def test_allows_unchanged_changelog() -> None:
+    assert validate_changelog(BASE_CHANGELOG, BASE_CHANGELOG) == []
+
+
+def test_allows_addition_under_unreleased() -> None:
+    candidate = BASE_CHANGELOG.replace(
+        "## [Unreleased]\n",
+        "## [Unreleased]\n\n### Fixed\n- Correct changelog validation\n",
+    )
+
+    assert validate_changelog(BASE_CHANGELOG, candidate) == []
+
+
+def test_rejects_addition_to_existing_release() -> None:
+    candidate = BASE_CHANGELOG.replace(
+        "- Existing feature\n",
+        "- Existing feature\n- Accidentally duplicated entry\n",
+    )
+
+    violations = validate_changelog(BASE_CHANGELOG, candidate)
+
+    assert len(violations) == 1
+    assert violations[0].section == "1.1.0"
+    assert violations[0].content == "- Accidentally duplicated entry"
+
+
+def test_allows_new_release_section() -> None:
+    candidate = BASE_CHANGELOG.replace(
+        "## [Unreleased]\n",
+        "## [Unreleased]\n\n## [1.2.0] - 2026-08-17\n\n### Added\n- New release\n",
+    )
+
+    assert validate_changelog(BASE_CHANGELOG, candidate) == []
+
+
+def test_rejects_only_historical_part_of_mixed_changes() -> None:
+    candidate = BASE_CHANGELOG.replace(
+        "## [Unreleased]\n",
+        "## [Unreleased]\n\n### Fixed\n- Valid fix\n",
+    ).replace(
+        "- Initial release\n",
+        "- Initial release\n- Invalid historical addition\n",
+    )
+
+    violations = validate_changelog(BASE_CHANGELOG, candidate)
+
+    assert [violation.section for violation in violations] == ["1.0.0"]
+    assert violations[0].content == "- Invalid historical addition"
+
+
+def test_rejects_addition_to_preamble() -> None:
+    candidate = BASE_CHANGELOG.replace(
+        "# Changelog\n",
+        "# Changelog\n\nDo not edit released entries.\n",
+    )
+
+    violations = validate_changelog(BASE_CHANGELOG, candidate)
+
+    assert len(violations) == 1
+    assert violations[0].section == "<preamble>"
+    assert violations[0].content == "Do not edit released entries."
+
+
+def test_rejects_changed_historical_header() -> None:
+    candidate = BASE_CHANGELOG.replace(
+        "## [1.1.0] - 2026-08-01",
+        "## [1.1.0] - 2026-08-02",
+    )
+
+    violations = validate_changelog(BASE_CHANGELOG, candidate)
+
+    assert len(violations) == 1
+    assert violations[0].section == "1.1.0"
+    assert violations[0].content == "## [1.1.0] - 2026-08-02"


### PR DESCRIPTION
## Summary

- add a standalone changelog scope validator that compares the PR version with the base branch
- allow additions under `[Unreleased]` and newly created release sections while rejecting additions to existing historical sections
- run scope validation for every PR that modifies `CHANGELOG.md`, independently of the existing title-prefix check
- add focused coverage for unchanged, Unreleased, new-release, historical, mixed, preamble, and header-change cases

Closes #91

## Testing

- `uv run pytest tests/test_validate_changelog.py -q` — 7 passed
- `uv run ruff check src/ tests/ scripts/validate_changelog.py`
- `uv run ruff format --check src/ tests/ scripts/validate_changelog.py`
- `uv run pre-commit run --files .github/workflows/ci.yml CHANGELOG.md scripts/validate_changelog.py tests/test_validate_changelog.py`
- `uv run harness-eval harness-security . --fail-on-warning`
- `uv run harness-eval harness-lint . --fail-on-error`

The full suite on Windows reached 918 passed with 13 existing platform-specific failures involving CRLF handling, the GBK locale, POSIX-style paths, and symlink privileges. The pull request CI runs the authoritative Linux suite.

## Checklist

- [ ] `uv run pytest tests/ -q` passes (awaiting Linux CI; see Windows note above)
- [x] `uv run ruff check src/ tests/` clean
- [x] `uv run ruff format --check src/ tests/` clean
- [x] `uv run harness-eval harness-security . --fail-on-warning` clean
- [x] `uv run harness-eval harness-lint . --fail-on-error` clean
- [x] Version bump not required; this is neither a feature nor a breaking change
- [x] Plugin manifest bump not required because the project version is unchanged
- [x] `CHANGELOG.md` updated under `[Unreleased]`