### PR TITLE
fix(rules): calibrate homoglyph, nested-section, and reference extraction

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "harness-eval",
       "source": "./",
-      "version": "7.10.0",
+      "version": "7.10.1",
       "description": "Evaluate AI agent setups for best practices, redundancy, security, and cross-component issues. 97 lint rules, cross-component security analysis, per-component rubric review, deep security audit, and single-skill evaluation."
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "harness-eval",
   "displayName": "Setup Eval",
-  "version": "7.10.0",
+  "version": "7.10.1",
   "description": "Evaluate AI agent setups for best practices, redundancy, security, and cross-component issues.",
   "author": {
     "name": "Benjamin Kapner"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [7.10.1] - 2026-08-19
+
+### Fixed
+- `security/mcp-tool-poisoning`: homoglyph detection now requires script mixing
+  within a token, so documents written in non-Latin scripts are no longer
+  flagged for containing their own alphabet. Substituted characters inside
+  Latin identifiers are still detected.
+- `quality/unfinished-content`: a heading whose content lives in subsections is
+  no longer reported as an empty section.
+- `content/broken-references`: reference extraction no longer treats environment
+  assignments as paths, no longer segments non-Latin prose as paths, and strips
+  trailing sentence punctuation before resolution.
+
 ## [7.10.0] - 2026-08-17
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "harness-eval"
-version = "7.10.0"
+version = "7.10.1"
 description = "Evaluate and compare AI agent setups through experiments, inspections, and rubric scoring."
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/harness_eval/__init__.py
+++ b/src/harness_eval/__init__.py
@@ -1,3 +1,3 @@
 """harness-eval: Evaluate and compare AI agent setups."""
 
-__version__ = "7.10.0"
+__version__ = "7.10.1"

--- a/src/harness_eval/inspection/rules/content/broken_references.py
+++ b/src/harness_eval/inspection/rules/content/broken_references.py
@@ -65,7 +65,17 @@ _KNOWN_EXTENSIONS = frozenset(
 )
 
 
+_TRAILING_PUNCT_RE = re.compile(r"[.,;:!?)]+$")
+_NON_ASCII_SEGMENT_RE = re.compile(r"[^\x00-\x7f]")
+
+
+def _strip_trailing_punctuation(ref: str) -> str:
+    return _TRAILING_PUNCT_RE.sub("", ref)
+
+
 def _is_not_a_file_ref(ref: str) -> bool:
+    if "=" in ref:
+        return True
     if _VERSION_RE.match(ref):
         return True
     if _GIT_REF_RE.search(ref):
@@ -81,6 +91,8 @@ def _is_not_a_file_ref(ref: str) -> bool:
     if ref.startswith("~"):
         return True
     if _PLACEHOLDER_RE.match(ref):
+        return True
+    if any(_NON_ASCII_SEGMENT_RE.search(seg) for seg in ref.split("/")):
         return True
     ext = ref.rsplit(".", 1)[-1].lower() if "." in ref else ""
     return bool(ext and ext not in _KNOWN_EXTENSIONS)
@@ -153,8 +165,11 @@ class BrokenReferences:
             for match in _DIR_REF_PATTERN.finditer(line_without_md_links):
                 refs_on_line.append(match.group(0).strip())
 
-            for ref in refs_on_line:
-                if ref.startswith(("http://", "https://", "#", "mailto:")):
+            for raw_ref in refs_on_line:
+                if raw_ref.startswith(("http://", "https://", "#", "mailto:")):
+                    continue
+                ref = _strip_trailing_punctuation(raw_ref)
+                if not ref:
                     continue
                 if _is_not_a_file_ref(ref):
                     continue

--- a/src/harness_eval/inspection/rules/quality/unfinished_content.py
+++ b/src/harness_eval/inspection/rules/quality/unfinished_content.py
@@ -46,7 +46,7 @@ _DEFERRED_PATTERNS: list[tuple[str, re.Pattern[str]]] = [
     ("not yet implemented", re.compile(r"\bnot\s+yet\s+(?:implemented|done|complete)\b", re.I)),
 ]
 
-_HEADING_RE = re.compile(r"^#{1,6}\s+\S")
+_HEADING_RE = re.compile(r"^(#{1,6})\s+\S")
 
 
 class UnfinishedContent:
@@ -78,7 +78,7 @@ class UnfinishedContent:
         lines = skill.raw_content.split("\n")
         tracker = ContextTracker()
 
-        prev_heading: tuple[int, str] | None = None
+        prev_heading: tuple[int, str, int] | None = None
         prev_heading_had_content = False
 
         for i, line in enumerate(lines):
@@ -94,22 +94,26 @@ class UnfinishedContent:
             if tracker.is_fenced():
                 continue
 
-            is_heading = bool(_HEADING_RE.match(stripped))
+            m = _HEADING_RE.match(stripped)
 
-            if is_heading:
+            if m:
+                cur_depth = len(m.group(1))
                 if prev_heading is not None and not prev_heading_had_content:
-                    h_line, h_text = prev_heading
-                    context.report(
-                        ReportDescriptor(
-                            message_id="empty_section",
-                            data={"line": str(h_line + 1), "heading": h_text},
-                            location=Location(
-                                file=skill.skill_md_path,
-                                start_line=h_line + 1,
-                            ),
+                    _h_line, _h_text, prev_depth = prev_heading
+                    if cur_depth <= prev_depth:
+                        context.report(
+                            ReportDescriptor(
+                                message_id="empty_section",
+                                data={"line": str(_h_line + 1), "heading": _h_text},
+                                location=Location(
+                                    file=skill.skill_md_path,
+                                    start_line=_h_line + 1,
+                                ),
+                            )
                         )
-                    )
-                prev_heading = (i, stripped.lstrip("#").strip())
+                    else:
+                        prev_heading_had_content = True
+                prev_heading = (i, stripped.lstrip("#").strip(), cur_depth)
                 prev_heading_had_content = False
                 continue
 
@@ -119,7 +123,7 @@ class UnfinishedContent:
             self._check_line(context, skill, line, stripped, i)
 
         if prev_heading is not None and not prev_heading_had_content:
-            h_line, h_text = prev_heading
+            h_line, h_text, _ = prev_heading
             context.report(
                 ReportDescriptor(
                     message_id="empty_section",

--- a/src/harness_eval/inspection/rules/security/mcp_tool_poisoning.py
+++ b/src/harness_eval/inspection/rules/security/mcp_tool_poisoning.py
@@ -87,6 +87,18 @@ _RTL_OVERRIDE_CHARS = {
     "⁩": "PDI",  # nosec B613
 }
 
+_TOKEN_RE = re.compile(r"[A-Za-z0-9_Ѐ-ӿͰ-Ͽ]+")
+
+
+def _is_mixed_script_token(char: str, line: str) -> bool:
+    """Return True if *char* appears in a token that also contains ASCII letters."""
+    for m in _TOKEN_RE.finditer(line):
+        token = m.group()
+        if char in token and re.search(r"[A-Za-z]", token):
+            return True
+    return False
+
+
 _HOMOGLYPH_MAP: dict[str, str] = {
     "А": "A (Cyrillic)",
     "В": "B (Cyrillic)",
@@ -209,7 +221,7 @@ class McpToolPoisoning:
                     )
 
             for char, char_name in _HOMOGLYPH_MAP.items():
-                if char in line:
+                if char in line and _is_mixed_script_token(char, line):
                     context.report(
                         ReportDescriptor(
                             message_id="mcp_unicode_deception",

--- a/tests/test_homoglyph_script_mixing.py
+++ b/tests/test_homoglyph_script_mixing.py
@@ -1,0 +1,40 @@
+"""Tests for homoglyph script-mixing gate in security/mcp-tool-poisoning."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from harness_eval.inspection.engine import lint
+
+
+def _make_skill(tmp_path: Path, body: str) -> str:
+    skill_dir = tmp_path / "test-skill"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text(f"---\nname: test-skill\ndescription: test\n---\n\n{body}")
+    return str(skill_dir)
+
+
+def _rule_ids(result: object) -> set[str]:
+    return {d.rule_id for d in result.diagnostics}
+
+
+def test_cyrillic_prose_no_homoglyph(tmp_path: Path) -> None:
+    body = "Этот навык помогает с развёртыванием приложений на сервере."
+    result = lint(_make_skill(tmp_path, body))
+    homoglyph_findings = [
+        d
+        for d in result.diagnostics
+        if d.rule_id == "security/mcp-tool-poisoning" and "homoglyph" in d.message
+    ]
+    assert not homoglyph_findings
+
+
+def test_mixed_script_identifier_fires(tmp_path: Path) -> None:
+    body = "Set the env var ANTHROPIC_АPI_KEY to your token."
+    result = lint(_make_skill(tmp_path, body))
+    homoglyph_findings = [
+        d
+        for d in result.diagnostics
+        if d.rule_id == "security/mcp-tool-poisoning" and "homoglyph" in d.message
+    ]
+    assert homoglyph_findings

--- a/tests/test_nested_section_content.py
+++ b/tests/test_nested_section_content.py
@@ -1,0 +1,36 @@
+"""Tests for nested-section suppression in quality/unfinished-content."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from harness_eval.inspection.engine import lint
+
+
+def _make_skill(tmp_path: Path, body: str) -> str:
+    skill_dir = tmp_path / "test-skill"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text(f"---\nname: test-skill\ndescription: test\n---\n\n{body}")
+    return str(skill_dir)
+
+
+def test_parent_with_subsection_no_empty(tmp_path: Path) -> None:
+    body = "## Parent\n\n### Child\n\nThis child has content.\n"
+    result = lint(_make_skill(tmp_path, body))
+    empty_findings = [
+        d
+        for d in result.diagnostics
+        if d.rule_id == "quality/unfinished-content" and "no content" in d.message
+    ]
+    assert not empty_findings
+
+
+def test_empty_sibling_still_fires(tmp_path: Path) -> None:
+    body = "## Empty\n\n## Next\n\nThis section has content.\n"
+    result = lint(_make_skill(tmp_path, body))
+    empty_findings = [
+        d
+        for d in result.diagnostics
+        if d.rule_id == "quality/unfinished-content" and "no content" in d.message
+    ]
+    assert any("Empty" in d.message for d in empty_findings)

--- a/tests/test_reference_extraction_artifacts.py
+++ b/tests/test_reference_extraction_artifacts.py
@@ -1,0 +1,39 @@
+"""Tests for reference extraction calibration in content/broken-references."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from harness_eval.inspection.engine import lint
+
+
+def _make_skill(tmp_path: Path, body: str, extra_files: dict[str, str] | None = None) -> str:
+    skill_dir = tmp_path / "test-skill"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text(f"---\nname: test-skill\ndescription: test\n---\n\n{body}")
+    for name, content in (extra_files or {}).items():
+        path = skill_dir / name
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content)
+    return str(skill_dir)
+
+
+def test_env_assignment_not_reported(tmp_path: Path) -> None:
+    body = "Set `MERMAID=plugins/x.ts` before running.\n"
+    result = lint(_make_skill(tmp_path, body))
+    broken = [d for d in result.diagnostics if d.rule_id == "content/broken-references"]
+    assert not broken
+
+
+def test_trailing_period_resolves(tmp_path: Path) -> None:
+    body = "Run `scripts/sync_docs.py.`\n"
+    result = lint(_make_skill(tmp_path, body, {"scripts/sync_docs.py": "# ok"}))
+    broken = [d for d in result.diagnostics if d.rule_id == "content/broken-references"]
+    assert not broken
+
+
+def test_genuinely_missing_still_reported(tmp_path: Path) -> None:
+    body = "See `scripts/missing.py` for details.\n"
+    result = lint(_make_skill(tmp_path, body))
+    broken = [d for d in result.diagnostics if d.rule_id == "content/broken-references"]
+    assert broken


### PR DESCRIPTION
## Summary

- `security/mcp-tool-poisoning`: homoglyph detection now requires script mixing within a token, so documents written in non-Latin scripts are no longer flagged for containing their own alphabet. Substituted characters inside Latin identifiers are still detected. A single Russian-language repository in the study corpus dropped from 3,258 findings to 66.
- `quality/unfinished-content`: a heading whose content lives in subsections is no longer reported as an empty section. Computes heading depth and suppresses when the next heading is deeper.
- `content/broken-references`: reference extraction no longer treats environment assignments (containing `=`) as paths, no longer segments non-Latin prose as paths, and strips trailing sentence punctuation before resolution.

Version bumped to 7.10.1 in pyproject.toml, `__init__.py`, plugin.json, marketplace.json.

This release is cited by an accompanying research paper. Needs a tag once merged.

## Test plan

- [x] 3 new test files (7 tests) covering both directions of each change
- [x] 931 tests pass, 0 failures
- [x] `ruff format` and `ruff check` clean